### PR TITLE
Build PHP with jpeg support.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -101,6 +101,7 @@ parts:
       - --with-mcrypt
       - --enable-exif
       - --enable-intl
+      - --with-jpeg-dir=/usr/lib
       - --disable-rpath
     stage-packages:
       # These are only included here until the OS snap stabilizes
@@ -110,6 +111,7 @@ parts:
       - libxml2-dev
       - libcurl4-openssl-dev
       - libpng12-dev
+      - libjpeg9-dev
       - libbz2-dev
       - libmcrypt-dev
     snap:


### PR DESCRIPTION
This PR fixes #24 by building PHP with jpeg support, which means Nextcloud can now generate thumbnails and previews. Please test with the following:

```bash
$ sudo snap install nextcloud --edge
```

Upload .jpg and .png images, and verify that thumbnails are generated. Also verify that, when selecting them, previews are successfully shown.