### PR TITLE
Increase PHP and Apache proxy timeout to 3600 seconds.

### DIFF
--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -146,7 +146,7 @@ Alias "/.well-known" "${SNAP_DATA}/certs/certbot/.well-known"
 </Files>
 
 # Setup the proxy to PHP-FPM
-ProxyTimeout 900
+ProxyTimeout 3600
 <FilesMatch \.php$>
     SetHandler "proxy:unix:${SNAP_DATA}/php/php-fpm.sock|fcgi://localhost/"
 </FilesMatch>

--- a/src/php/config/php.ini
+++ b/src/php/config/php.ini
@@ -365,7 +365,7 @@ expose_php = On
 ; Maximum execution time of each script, in seconds
 ; http://php.net/max-execution-time
 ; Note: This directive is hardcoded to 0 for the CLI SAPI
-max_execution_time = 30
+max_execution_time = 3600
 
 ; Maximum amount of time each script may spend parsing request data. It's a good
 ; idea to limit this time on productions servers in order to eliminate unexpectedly
@@ -375,7 +375,7 @@ max_execution_time = 30
 ; Development Value: 60 (60 seconds)
 ; Production Value: 60 (60 seconds)
 ; http://php.net/max-input-time
-max_input_time = 60
+max_input_time = 3600
 
 ; Maximum input variable nesting level
 ; http://php.net/max-input-nesting-level


### PR DESCRIPTION
Image verification noted a failure to upload 1.5GB file on rpi2, logs indicated a timeout occurred.