### PR TITLE
Add service that runs cron.php every 15 minutes

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -66,6 +66,12 @@ apps:
     restart-condition: always
     plugs: [network, network-bind]
 
+  nextcloud-cron:
+    command: nextcloud-cron
+    daemon: simple
+    restart-condition: always
+    plugs: [network, network-bind]
+
 parts:
   apache:
     plugin: apache

--- a/src/nextcloud/scripts/nextcloud-cron
+++ b/src/nextcloud/scripts/nextcloud-cron
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+export NEXTCLOUD_CONFIG_DIR=$SNAP_DATA/nextcloud/config
+
+echo -n "Waiting for Nextcloud config dir... "
+while [ ! -d "$NEXTCLOUD_CONFIG_DIR" ]; do
+	sleep 1
+done
+
+echo "done"
+
+while true; do
+	php -c $SNAP/config/php $SNAP/htdocs/cron.php
+	sleep 15m
+done


### PR DESCRIPTION
Fixes #39 

A second attempt based on #42 

I changed the name of the service to nextcloud-cron as suggested, and moved the script into src/nextcloud/scripts/nextcloud-cron as that seemed to make more sense.

When building, I needed to do:
snapcraft clean
snapcraft

So that the wildcard in nextcloud-customizations picked up the new nextcloud-cron script...