### PR TITLE
Add access to /media

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -26,7 +26,7 @@ apps:
     command: start-php-fpm
     daemon: simple
     restart-condition: always
-    plugs: [network, network-bind]
+    plugs: [network, network-bind, removable-media]
 
   # redis server daemon
   redis-server:
@@ -50,7 +50,7 @@ apps:
   # Nextcloud occ command
   occ:
     command: occ
-    plugs: [network, network-bind]
+    plugs: [network, network-bind, removable-media]
 
   enable-https:
     command: enable-https


### PR DESCRIPTION
Adds new storage locations capabilities to Nextcloud

* `/media` is a zone which is accessible by all snaps supporting the `removable-media` interface
* `home` is the home folder of the user and is accessible by all snaps supporting the `home` interface

Documentation on how to connect Nextcloud to these new locations is available in the wiki:
https://github.com/nextcloud/nextcloud-snap/wiki/Connecting-Nextcloud-to-the-filesystem