### PR TITLE
Spreedme integration

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -82,6 +82,8 @@ parts:
       - headers
       - proxy
       - proxy_fcgi
+      - proxy_http
+      - proxy_wstunnel
       - setenvif
       - env
       - rewrite

--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -54,6 +54,8 @@ LoadModule headers_module modules/mod_headers.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule proxy_module modules/mod_proxy.so
 LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
 LoadModule unixd_module modules/mod_unixd.so
 LoadModule dir_module modules/mod_dir.so
 LoadModule alias_module modules/mod_alias.so

--- a/src/apache/conf/ssl.conf
+++ b/src/apache/conf/ssl.conf
@@ -160,4 +160,20 @@ SSLRandomSeed connect file:/dev/urandom 512
     <IfDefine EnableHSTS>
         Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains;"
     </IfDefine>
+
+	#########################
+	#       Spreed.ME       #
+	#########################
+	<Location /webrtc>
+		ProxyPass http://127.0.0.1:8080/webrtc
+		ProxyPassReverse /webrtc
+	</Location>
+
+	<Location /webrtc/ws>
+		ProxyPass ws://127.0.0.1:8080/webrtc/ws
+	</Location>
+
+	ProxyVia On
+	ProxyPreserveHost On
+	RequestHeader set X-Forwarded-Proto 'https' env=HTTPS
 </VirtualHost>


### PR DESCRIPTION
Fixes #64 

The proxy configuration is commented out in the Apache `custom.conf` since users will need to use the command line to integrate Nextcloud with Spreed.ME anyway.

I don't feel comfortable enabling a connection to localhost:8080 by default. We don't know what might end up being loaded here via another Snap.

Documentation and test snaps are available here: https://help.nextcloud.com/t/spreed-me-snap-for-the-nextcloud-snap-beta/3757

We will re-evaluate this for Nextcloud 11.

## Todo

- [ ] Will be rebased once #71 is merged
- [ ] Update documentation to let people know they need to uncomment the Apache config