### PR TITLE
https: show better message when a dry-run succeeds.

### DIFF
--- a/src/https/scripts/enable-https
+++ b/src/https/scripts/enable-https
@@ -4,10 +4,14 @@
 
 extra_params=""
 cert_type=""
+dry_run=false
 
 while getopts ":dtsh" opt; do
 	case $opt in
-		d) extra_params="$extra_params --dry-run";;
+		d)
+			extra_params="$extra_params --dry-run"
+			dry_run=true
+			;;
 		t) extra_params="$extra_params --test-cert";;
 		s) cert_type="self-signed";;
 		h)
@@ -104,7 +108,11 @@ else
 			$domains 2>&1)
 	if [ $? -eq 0 ]; then
 		echo "done"
-		activate_certbot_certificate
+		if [ "$dry_run" = true ]; then
+			echo "Looks like you're ready for HTTPS!"
+		else
+			activate_certbot_certificate
+		fi
 	else
 		echo "error running certbot:"
 		echo ""


### PR DESCRIPTION
This PR fixes #74 by improving the message when a dry-run succeeds. It also no longer unnecessarily restarts Apache.

Test this PR out on amd64 with [this snap](http://people.canonical.com/~kyrofa/nextcloud-box/pr_75.snap).