### PR TITLE
Upgrade to Nextcloud 10.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -119,11 +119,11 @@ parts:
 
   nextcloud:
     plugin: copy
-    source: https://github.com/kyrofa/nextcloud.git
-    source-tag: 9.0.53
+    source: https://download.nextcloud.com/server/releases/nextcloud-10.0.1.tar.bz2
     files:
       '*': htdocs/
       '.htaccess': htdocs/
+      '.user.ini': htdocs/
 
   php:
     plugin: php

--- a/src/nextcloud/config/config.php
+++ b/src/nextcloud/config/config.php
@@ -50,11 +50,4 @@ $CONFIG = array(
     'host' => '/var/snap/'.$snap_name.'/current/redis/redis.sock',
     'port' => 0,
 ),
-
-/**
- * Nextcloud doesn't support hosting the config file out of the application, so
- * this version of Nextcloud has been patched slightly to allow for it. As a
- * result, we fail the integrity check, so we'll just disable it.
- */
-'integrity.check.disabled' => true,
 );

--- a/src/php/config/php.ini
+++ b/src/php/config/php.ini
@@ -175,7 +175,7 @@
 ;user_ini.filename = ".user.ini"
 
 ; To disable this feature set this option to empty value
-;user_ini.filename =
+user_ini.filename =
 
 ; TTL for user-defined php.ini files (time-to-live) in seconds. Default is 300 seconds (5 minutes)
 ;user_ini.cache_ttl = 300


### PR DESCRIPTION
This PR resolves #40 by upgrading to Nextcloud 10.0.1, which means we can finally use vanilla upstream and enable the integrity check!

Test it out on amd64 with [this snap](http://people.canonical.com/~kyrofa/nextcloud-box/pr_76.snap).