### PR TITLE
Move certificate migration to run-httpd.

### DIFF
--- a/src/apache/scripts/httpd-wrapper
+++ b/src/apache/scripts/httpd-wrapper
@@ -2,17 +2,6 @@
 
 . $SNAP/utilities/https-utilities
 
-# Rewrite live cert symlinks that aren't using the current symlink.
-# FIXME: Remove this migration once epochs and upgrade hooks are available.
-if certificates_are_active; then
-	self_signed_basename="$(basename $SELF_SIGNED_DIRECTORY)"
-	if [ "$(basename $(realpath $LIVE_CERTS_DIRECTORY))" = "$self_signed_basename" ]; then
-		activate_self_signed_certificate
-	else
-		activate_certbot_certificate
-	fi
-fi
-
 params=""
 if certificates_are_active; then
 	echo "Certificates have been activated: using HTTPS only"

--- a/src/apache/scripts/run-httpd
+++ b/src/apache/scripts/run-httpd
@@ -11,4 +11,18 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "All set! Running httpd..."
+
+. $SNAP/utilities/https-utilities
+
+# Rewrite live cert symlinks that aren't using the current symlink.
+# FIXME: Remove this migration once epochs and upgrade hooks are available.
+if certificates_are_active; then
+	self_signed_basename="$(basename $SELF_SIGNED_DIRECTORY)"
+	if [ "$(basename $(realpath $LIVE_CERTS_DIRECTORY))" = "$self_signed_basename" ]; then
+		activate_self_signed_certificate
+	else
+		activate_certbot_certificate
+	fi
+fi
+
 httpd-wrapper $@


### PR DESCRIPTION
Currently the code that takes care of migrating old certificates actually gets in the way of generating new certificates by causing Apache to get restarted in a loop. This PR fixes #103 by moving that migration code up a level so it isn't involved when restarting Apache.