### PR TITLE
https: rewrite certbot plugin.

### DIFF
--- a/src/https/certbot_nextcloud_plugin/webroot.py
+++ b/src/https/certbot_nextcloud_plugin/webroot.py
@@ -1,4 +1,4 @@
-"""Nextcloud webroot plugin."""
+"""Nextcloud Webroot plugin."""
 import argparse
 import collections
 import errno
@@ -27,36 +27,20 @@ logger = logging.getLogger(__name__)
 class Authenticator(common.Plugin):
     """Nextcloud Webroot Authenticator."""
 
-    description = "Place files in webroot directory"
+    description = "Place files in webroot directory without running chown"
 
     MORE_INFO = """\
 Authenticator plugin that performs http-01 challenge by saving
 necessary validation resources to appropriate paths on the file
 system. It expects that there is some other HTTP server configured
-to serve all files under specified web root ({0}). This differes
-from the normal Webroot authenticator by the fact that this plugin
-doesn't even attempt to use chown."""
+to serve all files under specified web root ({0})."""
 
     def more_info(self):  # pylint: disable=missing-docstring,no-self-use
         return self.MORE_INFO.format(self.conf("path"))
 
     @classmethod
     def add_parser_arguments(cls, add):
-        add("path", default=[], action=_WebrootPathAction,
-            help="public_html / webroot path. This can be specified multiple "
-                 "times to handle different domains; each domain will have "
-                 "the webroot path that preceded it.  For instance: `-w "
-                 "/var/www/example -d example.com -d www.example.com -w "
-                 "/var/www/thing -d thing.net -d m.thing.net`")
-        add("map", default={}, action=_WebrootMapAction,
-            help="JSON dictionary mapping domains to webroot paths; this "
-                 "implies -d for each entry. You may need to escape this from "
-                 "your shell. E.g.: --webroot-map "
-                 '\'{"eg1.is,m.eg1.is":"/www/eg1/", "eg2.is":"/www/eg2"}\' '
-                 "This option is merged with, but takes precedence over, -w / "
-                 "-d entries. At present, if you put webroot-map in a config "
-                 "file, it needs to be on a single line, like: webroot-map = "
-                 '{"example.com":"/var/www"}.')
+        add("path", type=str, default='', help="public_html / webroot path")
 
     def get_chall_pref(self, domain):  # pragma: no cover
         # pylint: disable=missing-docstring,no-self-use,unused-argument
@@ -73,98 +57,25 @@ doesn't even attempt to use chown."""
     def perform(self, achalls):  # pylint: disable=missing-docstring
         self._set_webroots(achalls)
 
-        self._create_challenge_dirs()
+        self._create_challenge_dirs(achalls)
 
         return [self._perform_single(achall) for achall in achalls]
 
     def _set_webroots(self, achalls):
-        if self.conf("path"):
-            webroot_path = self.conf("path")[-1]
-            logger.info("Using the webroot path %s for all unmatched domains.",
-                        webroot_path)
-            for achall in achalls:
-                self.conf("map").setdefault(achall.domain, webroot_path)
-        else:
-            known_webroots = list(set(six.itervalues(self.conf("map"))))
-            for achall in achalls:
-                if achall.domain not in self.conf("map"):
-                    new_webroot = self._prompt_for_webroot(achall.domain,
-                                                           known_webroots)
-                    # Put the most recently input
-                    # webroot first for easy selection
-                    try:
-                        known_webroots.remove(new_webroot)
-                    except ValueError:
-                        pass
-                    known_webroots.insert(0, new_webroot)
-                    self.conf("map")[achall.domain] = new_webroot
+        if not self.conf("path"):
+            raise errors.PluginError("Missing path")
 
-    def _prompt_for_webroot(self, domain, known_webroots):
-        webroot = None
+        webroot_path = self.conf("path")[-1]
+        logger.info("Using the webroot path %s for all domains.",
+                    webroot_path)
 
-        while webroot is None:
-            webroot = self._prompt_with_webroot_list(domain, known_webroots)
-
-            if webroot is None:
-                webroot = self._prompt_for_new_webroot(domain)
-
-        return webroot
-
-    def _prompt_with_webroot_list(self, domain, known_webroots):
-        display = zope.component.getUtility(interfaces.IDisplay)
-
-        while True:
-            code, index = display.menu(
-                "Select the webroot for {0}:".format(domain),
-                ["Enter a new webroot"] + known_webroots,
-                help_label="Help", cli_flag="--" + self.option_name("path"))
-            if code == display_util.CANCEL:
-                raise errors.PluginError(
-                    "Every requested domain must have a "
-                    "webroot when using the webroot plugin.")
-            elif code == display_util.HELP:
-                display.notification(
-                    "To use the webroot plugin, you need to have an "
-                    "HTTP server running on this system serving files "
-                    "for the requested domain. Additionally, this "
-                    "server should be serving all files contained in a "
-                    "public_html or webroot directory. The webroot "
-                    "plugin works by temporarily saving necessary "
-                    "resources in the HTTP server's webroot directory "
-                    "to pass domain validation challenges.")
-            else:  # code == display_util.OK
-                return None if index == 0 else known_webroots[index - 1]
-
-    def _prompt_for_new_webroot(self, domain):
-        display = zope.component.getUtility(interfaces.IDisplay)
-
-        while True:
-            code, webroot = display.directory_select(
-                "Input the webroot for {0}:".format(domain))
-            if code == display_util.HELP:
-                # Help can currently only be selected
-                # when using the ncurses interface
-                display.notification(display_util.DSELECT_HELP)
-            elif code == display_util.CANCEL:
-                return None
-            else:  # code == display_util.OK
-                try:
-                    return _validate_webroot(webroot)
-                except errors.PluginError as error:
-                    display.notification(str(error), pause=False)
-
-    def _create_challenge_dirs(self):
-        path_map = self.conf("map")
-        if not path_map:
-            raise errors.PluginError(
-                "Missing parts of webroot configuration; please set either "
-                "--webroot-path and --domains, or --webroot-map. Run with "
-                " --help webroot for examples.")
-        for name, path in path_map.items():
-            self.full_roots[name] = os.path.join(path, challenges.HTTP01.URI_ROOT_PATH)
+    def _create_challenge_dirs(self, achalls):
+        for achall in achalls:
+            self.full_roots[achall.domain] = os.path.join(
+                self.conf("path"), challenges.HTTP01.URI_ROOT_PATH)
 
             logger.debug("Creating root challenges validation dir at %s",
-                         self.full_roots[name])
+                         self.conf("path"))
 
             # Change the permissions to be writable (GH #1389)
             # Umask is used instead of chmod to ensure the client can also
@@ -175,22 +86,13 @@ doesn't even attempt to use chown."""
                 # This is coupled with the "umask" call above because
                 # os.makedirs's "mode" parameter may not always work:
                 # https://stackoverflow.com/questions/5231901/permission-problems-when-creating-a-dir-with-os-makedirs-python
-                os.makedirs(self.full_roots[name], 0o0755)
-
-                # Set owner as parent directory if possible
-#                try:
-#                    stat_path = os.stat(path)
-#                    os.chown(self.full_roots[name], stat_path.st_uid,
-#                             stat_path.st_gid)
-#                except OSError as exception:
-#                    logger.info("Unable to change owner and uid of webroot directory")
-#                    logger.debug("Error was: %s", exception)
+                os.makedirs(self.full_roots[achall.domain], 0o0755)
 
             except OSError as exception:
                 if exception.errno != errno.EEXIST:
                     raise errors.PluginError(
                         "Couldn't create root for {0} http-01 "
-                        "challenge responses: {1}", name, exception)
+                        "challenge responses: {1}", achall.domain, exception)
             finally:
                 os.umask(old_umask)
 
@@ -208,7 +110,7 @@ doesn't even attempt to use chown."""
         old_umask = os.umask(0o022)
 
         try:
-            with open(validation_path, "w") as validation_file:
+            with open(validation_path, "wb") as validation_file:
                 validation_file.write(validation.encode())
         finally:
             os.umask(old_umask)
@@ -236,55 +138,3 @@ doesn't even attempt to use chown."""
                     logger.info(
                         "Unable to clean up challenge directory %s", root_path)
                     logger.debug("Error was: %s", exc)
-
-
-class _WebrootMapAction(argparse.Action):
-    """Action class for parsing webroot_map."""
-
-    def __call__(self, parser, namespace, webroot_map, option_string=None):
-        for domains, webroot_path in six.iteritems(json.loads(webroot_map)):
-            webroot_path = _validate_webroot(webroot_path)
-            namespace.webroot_map.update(
-                (d, webroot_path) for d in cli.add_domains(namespace, domains))
-
-
-class _WebrootPathAction(argparse.Action):
-    """Action class for parsing webroot_path."""
-
-    def __init__(self, *args, **kwargs):
-        super(_WebrootPathAction, self).__init__(*args, **kwargs)
-        self._domain_before_webroot = False
-
-    def __call__(self, parser, namespace, webroot_path, option_string=None):
-        if self._domain_before_webroot:
-            raise errors.PluginError(
-                "If you specify multiple webroot paths, "
-                "one of them must precede all domain flags")
-
-        current_path = getattr(namespace, self.dest)
-        if current_path:
-            # Apply previous webroot to all matched
-            # domains before setting the new webroot path
-            prev_webroot = current_path[-1]
-            for domain in namespace.domains:
-                namespace.webroot_map.setdefault(domain, prev_webroot)
-        elif namespace.domains:
-            self._domain_before_webroot = True
-
-        current_path.append(_validate_webroot(webroot_path))
-        setattr(namespace, self.dest, current_path)
-
-
-def _validate_webroot(webroot_path):
-    """Validates and returns the absolute path of webroot_path.
-
-    :param str webroot_path: path to the webroot directory
-
-    :returns: absolute path of webroot_path
-    :rtype: str
-
-    """
-    if not os.path.isdir(webroot_path):
-        raise errors.PluginError(webroot_path + " does not exist or is not a directory")
-
-    return os.path.abspath(webroot_path)

--- a/src/https/setup.py
+++ b/src/https/setup.py
@@ -5,7 +5,7 @@ setup(
 	name='nextcloud',
 	packages=find_packages(),
 	install_requires=[
-		'certbot',
+		'certbot==0.9.3',
 		'zope.interface',
 	],
 	entry_points={


### PR DESCRIPTION
Currently the certbot plugin used in the snap is a copy of the webroot plugin from upstream certbot with the chown bits commented out. However, it turns out that the webroot plugin as-written cannot be used as an external plugin. It's far more complicated than we needed anyway, so this PR fixes #159 by rewriting it to be exactly what we need.