### PR TITLE
dailies: fix overly-fragile version regex.

### DIFF
--- a/.travis/cron.sh
+++ b/.travis/cron.sh
@@ -6,7 +6,7 @@ latest_stable_url="https://download.nextcloud.com/server/daily/latest-stable11.t
 rewrite_snapcraft_yaml()
 {
 	sed -ri "s|(source:\s+).*download.nextcloud.com.*$|\1$1|" snapcraft.yaml
-	sed -ri "s|(version:\s+).*$|\1$2|" snapcraft.yaml
+	sed -ri "s|(^version:\s+).*$|\1$2|" snapcraft.yaml
 }
 
 echo "Requesting build of latest master..."


### PR DESCRIPTION
Fix #166 by only matching the snap version and not every "version" string.