### PR TITLE
Allow standard .well-known paths to work

### DIFF
--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -121,6 +121,13 @@ DocumentRoot "${SNAP}/htdocs"
     # Controls who can get stuff from this server.
     #
     Require all granted
+
+    # Include Nextcloud's .htaccess file directly. In a typical setup this would
+    # be dangerous since it increases the capability of the .htaccess file in
+    # case an attacker was able to modify it, but that's not actually possible
+    # on Snappy (since the .htaccess file is read-only) so we'll do it here so
+    # as to avoid manually copying it in and needing to maintain it.
+    Include ${SNAP}/htdocs/.htaccess
 </Directory>
 
 # Serve static assets for apps in a writable location.
@@ -131,8 +138,8 @@ Alias "/extra-apps" "${SNAP_DATA}/nextcloud/extra-apps"
 </Directory>
 
 # Serve ACME authentication data (Let's Encrypt).
-Alias "/.well-known" "${SNAP_DATA}/certs/certbot/.well-known"
-<Directory "${SNAP_DATA}/certs/certbot/.well-known">
+Alias "/.well-known/acme-challenge" "${SNAP_DATA}/certs/certbot/.well-known/acme-challenge"
+<Directory "${SNAP_DATA}/certs/certbot/.well-known/acme-challenge">
     AllowOverride None
     Require all granted
 </Directory>
@@ -176,15 +183,4 @@ TypesConfig conf/mime.types
 # Only enable SSL if requested
 <IfDefine EnableHTTPS>
     Include ${SNAP}/conf/ssl.conf
-</IfDefine>
-<IfDefine !EnableHTTPS>
-    # In this case, we're HTTP only.
-    <VirtualHost *:80>
-        # Include Nextcloud's .htaccess file directly. In a typical setup this would
-        # be dangerous since it increases the capability of the .htaccess file in
-        # case an attacker was able to modify it, but that's not actually possible
-        # on Snappy (since the .htaccess file is read-only) so we'll do it here so
-        # as to avoid manually copying it in and needing to maintain it.
-        Include ${SNAP}/htdocs/.htaccess
-    </VirtualHost>
 </IfDefine>

--- a/src/apache/conf/ssl.conf
+++ b/src/apache/conf/ssl.conf
@@ -79,12 +79,6 @@ SSLRandomSeed connect file:/dev/urandom 512
 
 # Virtual host for HTTPS.
 <VirtualHost *:443>
-    # Include Nextcloud's .htaccess file directly. In a typical setup this would
-    # be dangerous since it increases the capability of the .htaccess file in
-    # case an attacker was able to modify it, but that's not actually possible
-    # on Snappy (since the .htaccess file is read-only) so we'll do it here so
-    # as to avoid manually copying it in and needing to maintain it.
-    Include ${SNAP}/htdocs/.htaccess
 
     SSLEngine on
     SSLHonorCipherOrder On


### PR DESCRIPTION
Make the alias for acme-challenge less greedy.
Include the rewrites from htaccess in the correct directory
Fix #111