### PR TITLE
Add to description: this is Nextcloud server

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ name: nextcloud
 version: 11.0.1snap3
 summary: Nextcloud Server
 description: |
- Access, share and protect your files, calendars, contacts, communication and
+ Nextcloud server running on Apache with MySQL. Access, share, and protect your files, calendars, contacts, communications, and
  more at home and in your enterprise.
 confinement: strict
 


### PR DESCRIPTION
Mention in the package description that this is the Nextcloud server part, not the client. This is currently not mentioned anywhere, and is a bit confusing.