### PR TITLE
CI: use docker to build snap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: generic
 
+sudo: required
+services: [docker]
+
+script: docker run -v $(pwd):$(pwd) -w $(pwd) -t ubuntu:xenial sh -c
+        "apt update -qq && apt install snapcraft -y && snapcraft"
+
 after_success:
 - ssh-keyscan -t rsa -H git.launchpad.net > ~/.ssh/known_hosts
 


### PR DESCRIPTION
This PR resolves #213 by using Docker on Travis to verify that the snap at least builds on amd64.