### PR TITLE
many: place all pidfiles and sockets in /tmp.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -122,6 +122,7 @@ parts:
     files:
       src/apache/scripts/*: bin/
       src/apache/conf/*: conf/
+      src/apache/utilities/*: utilities/
 
   nextcloud:
     plugin: dump
@@ -191,6 +192,7 @@ parts:
     files:
       src/redis/config/*: config/redis/
       src/redis/scripts/*: bin/
+      src/redis/utilities/*: utilities/
 
   # Copy over our PHP configuration file.
   php-customizations:
@@ -198,6 +200,7 @@ parts:
     files:
       src/php/config/*: config/php/
       src/php/scripts/*: bin/
+      src/php/utilities/*: utilities/
     stage-packages: [mawk]
 
   # Copy over our Nextcloud configuration files
@@ -206,6 +209,7 @@ parts:
     files:
       src/nextcloud/config/*: htdocs/config/
       src/nextcloud/scripts/*: bin/
+      src/nextcloud/utilities/*: utilities/
 
   # Download the boost headers for MySQL. Note that the version used may need to
   # be updated if the version of MySQL changes.
@@ -283,6 +287,7 @@ parts:
       src/mysql/start_mysql: bin/
       src/mysql/my.cnf: my.cnf
       src/mysql/mysql.server: support-files/
+      src/mysql/utilities/*: utilities/
 
   mdns-publisher:
     plugin: go

--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -33,7 +33,7 @@ Mutex pthread
 
 #
 # PidFile: Allows you to place the pidfile in a specific location.
-PidFile "${SNAP_DATA}/apache/httpd.pid"
+PidFile "${APACHE_PIDFILE}"
 
 #
 # Dynamic Shared Object (DSO) Support
@@ -155,7 +155,7 @@ Alias "/.well-known/acme-challenge" "${SNAP_DATA}/certs/certbot/.well-known/acme
 # Setup the proxy to PHP-FPM
 ProxyTimeout 3600
 <FilesMatch \.php$>
-    SetHandler "proxy:unix:${SNAP_DATA}/php/php-fpm.sock|fcgi://localhost/"
+    SetHandler "proxy:unix:${PHP_FPM_SOCKET}|fcgi://localhost/"
 </FilesMatch>
 
 <Proxy "fcgi://localhost/">

--- a/src/apache/scripts/httpd-wrapper
+++ b/src/apache/scripts/httpd-wrapper
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 . $SNAP/utilities/https-utilities
+. $SNAP/utilities/apache-utilities
+. $SNAP/utilities/php-utilities
 
 params=""
 if certificates_are_active; then

--- a/src/apache/utilities/apache-utilities
+++ b/src/apache/utilities/apache-utilities
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+export APACHE_PIDFILE="/tmp/pids/httpd.pid"
+
+mkdir -p -m 750 "$(dirname $APACHE_PIDFILE)"
+
+restart_apache_if_running()
+{
+	if [ -f "$APACHE_PIDFILE" ]; then
+		# Restart apache by stopping it and letting systemd start it again.
+		apache_pid=$(cat "$APACHE_PIDFILE")
+		echo -n "Restarting apache... "
+		output=$(httpd-wrapper -k stop 2>&1)
+		if [ $? -eq 0 ]; then
+			while kill -0 $apache_pid 2>/dev/null; do
+				sleep 1
+			done
+			echo "done"
+		else
+			echo "error"
+			echo "$output"
+		fi
+	fi
+}

--- a/src/https/utilities/https-utilities
+++ b/src/https/utilities/https-utilities
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+. $SNAP/utilities/apache-utilities
+
 SNAP_CURRENT=$(dirname $SNAP_DATA)/current
 
 LIVE_CERTS_DIRECTORY=$SNAP_CURRENT/certs/live
@@ -20,8 +22,6 @@ CUSTOM_ENABLE_HSTS=$CUSTOM_DIRECTORY/hsts
 
 CERTBOT_DIRECTORY=$SNAP_CURRENT/certs/certbot
 CERTBOT_LIVE_DIRECTORY=$CERTBOT_DIRECTORY/config/live
-
-APACHE_PIDFILE=$SNAP_DATA/apache/httpd.pid
 
 # If this function is run multiple times it will replace the certificate
 # and key if they're already present.
@@ -133,23 +133,4 @@ run_certbot()
 	certbot --text --config-dir $CERTBOT_DIRECTORY/config \
 	               --work-dir $CERTBOT_DIRECTORY/work \
 	               --logs-dir $CERTBOT_DIRECTORY/logs $@
-} 
-
-restart_apache_if_running()
-{
-	if [ -f "$APACHE_PIDFILE" ]; then
-		# Restart apache by stopping it and letting systemd start it again.
-		apache_pid=$(cat "$APACHE_PIDFILE")
-		echo -n "Restarting apache... "
-		output=$(httpd-wrapper -k stop 2>&1)
-		if [ $? -eq 0 ]; then
-			while kill -0 $apache_pid 2>/dev/null; do
-				sleep 1
-			done
-			echo "done"
-		else
-			echo "error"
-			echo "$output"
-		fi
-	fi
 }

--- a/src/mysql/mysql.server
+++ b/src/mysql/mysql.server
@@ -43,6 +43,8 @@
 # If you change base dir, you must also change datadir. These may get
 # overwritten by settings in the MySQL configuration files.
 
+. $SNAP/utilities/mysql-utilities
+
 basedir=$SNAP
 datadir=$SNAP_DATA/mysql
 
@@ -60,7 +62,7 @@ lock_file_path="$lockdir/mysql"
 # The following variables are only set for letting mysql.server find things.
 
 # Set some defaults
-mysqld_pid_file_path=
+mysqld_pid_file_path="$MYSQL_PIDFILE"
 if test -z "$basedir"
 then
   basedir=/
@@ -280,7 +282,7 @@ case "$mode" in
     then
       # Give extra arguments to mysqld with the my.cnf file. This script
       # may be overwritten at next upgrade.
-      $bindir/mysqld_safe --datadir="$datadir" --pid-file="$mysqld_pid_file_path" --lc-messages-dir="$SNAP/share" --socket="$SNAP_DATA/mysql/mysql.sock" $other_args >/dev/null 2>&1 &
+      $bindir/mysqld_safe --datadir="$datadir" --pid-file="$mysqld_pid_file_path" --lc-messages-dir="$SNAP/share" --socket="$MYSQL_SOCKET" $other_args >/dev/null 2>&1 &
       wait_for_pid created "$!" "$mysqld_pid_file_path"; return_value=$?
 
       # Make lock for RedHat / SuSE

--- a/src/mysql/start_mysql
+++ b/src/mysql/start_mysql
@@ -1,9 +1,9 @@
 #!/bin/sh
 
+. $SNAP/utilities/mysql-utilities
+
 root_option_file="$SNAP_DATA/mysql/root.ini"
 nextcloud_password_file="$SNAP_DATA/mysql/nextcloud_password"
-mysqld_pid_file_path=$SNAP_DATA/mysql/`hostname`.pid
-mysql_socket_file_path="/var/snap/$SNAP_NAME/current/mysql/mysql.sock"
 new_install=false
 
 # Make sure the database is initialized (this is safe to run if already
@@ -32,7 +32,7 @@ if [ $new_install = true ]; then
 
 	# Save root user information
 	echo "[client]" >> $root_option_file
-	echo "socket=$mysql_socket_file_path" >> $root_option_file
+	echo "socket=$MYSQL_SOCKET" >> $root_option_file
 	echo "user=root" >> $root_option_file
 	chmod 600 $root_option_file
 
@@ -61,10 +61,7 @@ SQL
 fi
 
 # Wait here until mysql is running
-echo "Waiting for server..."
-while [ ! -f "$mysqld_pid_file_path" -o ! -S "$mysql_socket_file_path" ]; do
-	sleep 1
-done
+wait_for_mysql
 
 # Check and upgrade mysql tables if necessary. This will return 0 if the upgrade
 # succeeded, in which case we need to restart mysql.
@@ -74,10 +71,8 @@ if [ $? -eq 0 ]; then
 	echo "Restarting mysql server after upgrade..."
 	$SNAP/support-files/mysql.server restart
 
-	echo "Waiting for server to come back after upgrade..."
-	while [ ! -f "$mysqld_pid_file_path" -o ! -S "$mysql_socket_file_path" ]; do
-        	sleep 1
-	done
+	# Wait for server to come back after upgrade
+	wait_for_mysql
 fi
 
 # If this was a new installation, wait until the server is all up and running
@@ -89,7 +84,7 @@ fi
 
 # Wait here until mysql exits (turn a forking service into simple). This is
 # only needed for Ubuntu Core 15.04, as 16.04 supports forking services.
-mysqld_pid=$(cat "$mysqld_pid_file_path")
-while kill -0 $mysqld_pid 2>/dev/null; do
+pid=$(mysql_pid)
+while kill -0 "$pid" 2>/dev/null; do
 	sleep 1
 done

--- a/src/mysql/utilities/mysql-utilities
+++ b/src/mysql/utilities/mysql-utilities
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+export MYSQL_PIDFILE="/tmp/pids/mysql.pid"
+export MYSQL_SOCKET="/tmp/sockets/mysql.sock"
+
+mkdir -p -m 750 "$(dirname $MYSQL_PIDFILE)"
+mkdir -p -m 750 "$(dirname $MYSQL_SOCKET)"
+
+mysql_is_running()
+{
+	[ -f "$MYSQL_PIDFILE" -a -S "$MYSQL_SOCKET" ]
+}
+
+wait_for_mysql()
+{
+	if ! mysql_is_running; then
+		echo -n "Waiting for MySQL... "
+		while ! mysql_is_running; do
+			sleep 1
+		done
+		echo "done"
+	fi
+}
+
+mysql_pid()
+{
+	if mysql_is_running; then
+		cat "$MYSQL_PIDFILE"
+	else
+		echo "Unable to get MySQL PID as it's not yet running" >&2
+		echo ""
+	fi
+}

--- a/src/nextcloud/config/autoconfig.php
+++ b/src/nextcloud/config/autoconfig.php
@@ -12,7 +12,7 @@ $AUTOCONFIG = array(
 
 'dbtype' => 'mysql',
 
-'dbhost' => 'localhost:'.$data_path.'/mysql/mysql.sock',
+'dbhost' => 'localhost:'.getenv('MYSQL_SOCKET'),
 
 'dbname' => 'nextcloud',
 

--- a/src/nextcloud/config/config.php
+++ b/src/nextcloud/config/config.php
@@ -47,7 +47,7 @@ $CONFIG = array(
 'memcache.locking' => '\OC\Memcache\Redis',
 'memcache.local' => '\OC\Memcache\Redis',
 'redis' => array(
-    'host' => '/var/snap/'.$snap_name.'/current/redis/redis.sock',
+    'host' => getenv('REDIS_SOCKET'),
     'port' => 0,
 ),
 );

--- a/src/nextcloud/scripts/nextcloud-cron
+++ b/src/nextcloud/scripts/nextcloud-cron
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export NEXTCLOUD_CONFIG_DIR=$SNAP_DATA/nextcloud/config
+. $SNAP/utilities/nextcloud-utilities
 
 echo -n "Waiting for Nextcloud config dir... "
 while [ ! -d "$NEXTCLOUD_CONFIG_DIR" ]; do

--- a/src/nextcloud/scripts/occ
+++ b/src/nextcloud/scripts/occ
@@ -1,5 +1,14 @@
 #!/bin/sh
 
-export NEXTCLOUD_CONFIG_DIR=$SNAP_DATA/nextcloud/config
+. $SNAP/utilities/php-utilities
+. $SNAP/utilities/nextcloud-utilities
+
+if [ $(id -u) -ne 0 ]; then
+	echo "This utility needs to run as root"
+	exit 1
+fi
+
+# occ can't do much before PHP FPM is up and running
+wait_for_php
 
 php -c $SNAP/config/php $SNAP/htdocs/occ $*

--- a/src/nextcloud/scripts/setup_nextcloud
+++ b/src/nextcloud/scripts/setup_nextcloud
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+. $SNAP/utilities/php-utilities
+. $SNAP/utilities/nextcloud-utilities
+. $SNAP/utilities/redis-utilities
+
 # Make sure nextcloud directory exists
 mkdir -p -m 750 $SNAP_COMMON/nextcloud
 
@@ -9,16 +13,11 @@ mkdir -p -m 750 $SNAP_COMMON/nextcloud/tmp
 # Make sure nextcloud extra-apps directory exists (for user apps)
 mkdir -p -m 750 $SNAP_DATA/nextcloud/extra-apps
 
-# Wait for PHP FPM to be up and running before continuing, since we need to make
-# sure we can use occ below.
-php_pid_file_path=$SNAP_DATA/php/php-fpm.pid
-echo "Waiting for PHP..."
-while [ ! -f "$php_pid_file_path" ]; do
-	sleep 1
-done
+# We need both PHP and redis up and running before we can use occ
+wait_for_php
+wait_for_redis
 
 # If this is a new install, make sure it's configured correctly
-NEXTCLOUD_CONFIG_DIR=$SNAP_DATA/nextcloud/config
 if [ ! -d "$NEXTCLOUD_CONFIG_DIR" ]; then
 	echo "Configuring nextcloud..."
 	cp -r $SNAP/htdocs/config $NEXTCLOUD_CONFIG_DIR
@@ -26,7 +25,7 @@ else
 	# This is not a new installation, so we don't want to overwrite the config.
 	# We do, however, want to make sure we incorporate the new capabilities of
 	# this snap version, namely, using Redis for the memcache and file locking.
-	occ config:system:set redis host --value="/var/snap/$SNAP_NAME/current/redis/redis.sock" --type=string
+	occ config:system:set redis host --value="$REDIS_SOCKET" --type=string
 	occ config:system:set redis port --value=0 --type=integer
 	occ config:system:set memcache.locking --value="\OC\Memcache\Redis" --type=string
 	occ config:system:set memcache.local --value="\OC\Memcache\Redis" --type=string

--- a/src/nextcloud/utilities/nextcloud-utilities
+++ b/src/nextcloud/utilities/nextcloud-utilities
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+export NEXTCLOUD_CONFIG_DIR=$SNAP_DATA/nextcloud/config

--- a/src/php/config/php-fpm.conf
+++ b/src/php/config/php-fpm.conf
@@ -14,7 +14,7 @@
 ; Pid file
 ; Note: the default prefix is /home/ubuntu/src/nextcloud-snap/parts/php/install/var
 ; Default Value: none
-pid = ${SNAP_DATA}/php/php-fpm.pid
+pid = ${PHP_FPM_PIDFILE}
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written

--- a/src/php/config/php-fpm.d/www.conf
+++ b/src/php/config/php-fpm.d/www.conf
@@ -33,7 +33,7 @@ group = root
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = ${SNAP_DATA}/php/php-fpm.sock
+listen = ${PHP_FPM_SOCKET}
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)

--- a/src/php/scripts/start-php-fpm
+++ b/src/php/scripts/start-php-fpm
@@ -1,17 +1,16 @@
 #!/bin/sh
 
+. $SNAP/utilities/mysql-utilities
+. $SNAP/utilities/php-utilities
+. $SNAP/utilities/redis-utilities
+
 mkdir -p -m 750 ${SNAP_DATA}/php
 
-mysqld_pid_file_path=$SNAP_DATA/mysql/`hostname`.pid
-# Wait for mysql to be up and running, since we need to make sure
-# we run the upgrade process.
-echo "Waiting for mysql..."
-while [ ! -f "$mysqld_pid_file_path" ]; do
-	sleep 1
-done
+# We need to make sure mysql is running so we can run the migration process
+wait_for_mysql
 
 # Wait until we have an nextcloud mysql password
-echo "Obtaining nextcloud mysql credentials..."
+echo -n "Obtaining nextcloud mysql credentials... "
 nextcloud_password_path=$SNAP_DATA/mysql/nextcloud_password
 timeout=10
 while [ $timeout -gt 0 -a ! -e $nextcloud_password_path ]; do
@@ -19,11 +18,13 @@ while [ $timeout -gt 0 -a ! -e $nextcloud_password_path ]; do
 	sleep 1
 done
 if [ ! -e $nextcloud_password_path ]; then
+	echo ""
 	echo -n "Timed out while attempting to obtain nextcloud mysql password. "
 	echo -n "This isn't unusual when starting up for the first time after "
 	echo "an install or an upgrade. Will try again."
 	exit 1
 fi
+echo "done"
 
 # Tends to be between 30-50MB
 average_php_memory_requirement=50

--- a/src/php/utilities/php-utilities
+++ b/src/php/utilities/php-utilities
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+export PHP_FPM_PIDFILE="/tmp/pids/php-fpm.pid"
+export PHP_FPM_SOCKET="/tmp/sockets/php-fpm.sock"
+
+mkdir -p -m 750 "$(dirname $PHP_FPM_PIDFILE)"
+mkdir -p -m 750 "$(dirname $PHP_FPM_SOCKET)"
+
+php_is_running()
+{
+	[ -f "$PHP_FPM_PIDFILE" -a -S "$PHP_FPM_SOCKET" ]
+}
+
+wait_for_php()
+{
+	if ! php_is_running; then
+		echo -n "Waiting for PHP... "
+		while ! php_is_running; do
+			sleep 1
+		done
+		echo "done"
+	fi
+}
+
+php_pid()
+{
+	if php_is_running; then
+		cat "$PHP_FPM_PIDFILE"
+	else
+		echo "Unable to get PHP PID as it's not yet running" >&2
+		echo ""
+	fi
+}

--- a/src/redis/config/redis.conf
+++ b/src/redis/config/redis.conf
@@ -98,7 +98,7 @@ tcp-backlog 511
 # incoming connections. There is no default, so Redis will not listen
 # on a unix socket when not specified.
 #
-unixsocket ${SNAP_DATA}/redis/redis.sock
+unixsocket ${REDIS_SOCKET}
 # unixsocketperm 700
 
 # Close the connection after a client is idle for N seconds (0 to disable)
@@ -147,7 +147,7 @@ supervised no
 #
 # Creating a pid file is best effort: if Redis is not able to create it
 # nothing bad happens, the server will start and run normally.
-pidfile ${SNAP_DATA}/redis/redis.pid
+pidfile ${REDIS_PIDFILE}
 
 # Specify the server verbosity level.
 # This can be one of:

--- a/src/redis/scripts/start-redis-server
+++ b/src/redis/scripts/start-redis-server
@@ -1,8 +1,10 @@
 #!/bin/sh
 
+. $SNAP/utilities/redis-utilities
+
 mkdir -p -m 750 ${SNAP_DATA}/redis
 
 # redis doesn't support environment variables in its config files. Thankfully
 # it supports reading the config file from stdin though, so we'll rewrite the
 # config file on the fly and pipe it in.
-sed -e "s|\${SNAP_DATA}|$SNAP_DATA|" $SNAP/config/redis/redis.conf | redis-server -
+sed -e "s|\${SNAP_DATA}|$SNAP_DATA|;s|\${REDIS_PIDFILE}|$REDIS_PIDFILE|;s|\${REDIS_SOCKET}|$REDIS_SOCKET|" $SNAP/config/redis/redis.conf | redis-server -

--- a/src/redis/utilities/redis-utilities
+++ b/src/redis/utilities/redis-utilities
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+export REDIS_PIDFILE="/tmp/pids/redis.pid"
+export REDIS_SOCKET="/tmp/sockets/redis.sock"
+
+mkdir -p -m 750 "$(dirname $REDIS_PIDFILE)"
+mkdir -p -m 750 "$(dirname $REDIS_SOCKET)"
+
+redis_is_running()
+{
+	[ -f "$REDIS_PIDFILE" -a -S "$REDIS_SOCKET" ]
+}
+
+wait_for_redis()
+{
+	if ! redis_is_running; then
+		echo -n "Waiting for redis... "
+		while ! redis_is_running; do
+			sleep 1
+		done
+		echo "done"
+	fi
+}
+
+redis_pid()
+{
+	if redis_is_running; then
+		cat "$REDIS_PIDFILE"
+	else
+		echo "Unable to get redis PID as it's not yet running" >&2
+		echo ""
+	fi
+}


### PR DESCRIPTION
This PR fixes #151 by placing all pidfiles and sockets in /tmp.

Until recently, /tmp within a snap was unique to the app in the snap. This meant that any sockets or pidfiles placed into /tmp in app A was not accessible from app B (as it saw a separate /tmp).

As of snap-confine v1.0.43, this is no longer the case. /tmp is now unique snap-wide: /tmp for app A is the same /tmp as app B as long as both apps are contained within the same snap.

This finally gives us a place accessible from confinement that's wiped on each boot. It's the place to put pidfiles and sockets so hard reboots don't cause future failures.