### PR TITLE
Add new command for manually installing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ There are a few CLI utilities included:
 - `nextcloud.disable-https`:
     - Disable HTTPS (does not remove certificates). Note that it requires
       `sudo`.
+- `nextcloud.manual-install`:
+    - Manually install Nextcloud instead of visiting it in your browser. This
+      allows you to create the admin user via the CLI. Note that it requires
+      `sudo`.
 
 
 ## Where is my stuff?

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,6 +80,11 @@ apps:
     restart-condition: always
     plugs: [network, network-bind, removable-media]
 
+  # Command for manually installing instead of visiting site to create admin.
+  manual-install:
+    command: manual-install
+    plugs: [network, network-bind, removable-media]
+
 parts:
   apache:
     plugin: apache

--- a/src/mysql/start_mysql
+++ b/src/mysql/start_mysql
@@ -3,7 +3,6 @@
 . $SNAP/utilities/mysql-utilities
 
 root_option_file="$SNAP_DATA/mysql/root.ini"
-nextcloud_password_file="$SNAP_DATA/mysql/nextcloud_password"
 new_install=false
 
 # Make sure the database is initialized (this is safe to run if already
@@ -79,7 +78,7 @@ fi
 # before saving off the nextcloud user's password. This way the presence of the
 # file can be used as a signal that mysql is ready to be used.
 if [ $new_install = true ]; then
-	echo "$nextcloud_password" > $nextcloud_password_file
+	mysql_set_nextcloud_password "$nextcloud_password"
 fi
 
 # Wait here until mysql exits (turn a forking service into simple). This is

--- a/src/mysql/utilities/mysql-utilities
+++ b/src/mysql/utilities/mysql-utilities
@@ -2,6 +2,7 @@
 
 export MYSQL_PIDFILE="/tmp/pids/mysql.pid"
 export MYSQL_SOCKET="/tmp/sockets/mysql.sock"
+export NEXTCLOUD_PASSWORD_FILE="$SNAP_DATA/mysql/nextcloud_password"
 
 mkdir -p -m 750 "$(dirname $MYSQL_PIDFILE)"
 mkdir -p -m 750 "$(dirname $MYSQL_SOCKET)"
@@ -28,6 +29,22 @@ mysql_pid()
 		cat "$MYSQL_PIDFILE"
 	else
 		echo "Unable to get MySQL PID as it's not yet running" >&2
+		echo ""
+	fi
+}
+
+mysql_set_nextcloud_password()
+{
+	echo "$1" > "$NEXTCLOUD_PASSWORD_FILE"
+	chmod 600 "$NEXTCLOUD_PASSWORD_FILE"
+}
+
+mysql_get_nextcloud_password()
+{
+	if [ -f "$NEXTCLOUD_PASSWORD_FILE" ]; then
+		cat "$NEXTCLOUD_PASSWORD_FILE"
+	else
+		echo "MySQL Nextcloud password has not yet been generated" >&2
 		echo ""
 	fi
 }

--- a/src/nextcloud/config/autoconfig.php
+++ b/src/nextcloud/config/autoconfig.php
@@ -3,12 +3,11 @@
 $snap_name = getenv('SNAP_NAME');
 
 $data_path = '/var/snap/'.$snap_name.'/current';
-$common_data_path = '/var/snap/'.$snap_name.'/common';
 
 $database_password = trim(file_get_contents($data_path . '/mysql/nextcloud_password'));
 
 $AUTOCONFIG = array(
-'directory' => $common_data_path.'/nextcloud/data',
+'directory' => getenv('NEXTCLOUD_DATA_DIR'),
 
 'dbtype' => 'mysql',
 

--- a/src/nextcloud/scripts/manual-install
+++ b/src/nextcloud/scripts/manual-install
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+. $SNAP/utilities/php-utilities
+. $SNAP/utilities/mysql-utilities
+. $SNAP/utilities/nextcloud-utilities
+
+COMMAND="nextcloud.manual-install"
+
+print_usage()
+{
+	echo "Usage:"
+	echo "    $COMMAND -h"
+	echo "    Display this help message."
+	echo ""
+	echo "    $COMMAND <username> <password>"
+	echo "    Install Nextcloud, creating the admin user with the provided"
+	echo "    credentials."
+}
+
+while getopts ":h" opt; do
+	case $opt in
+		h)
+			print_usage
+			exit 0
+			;;
+		\?)
+			echo "Invalid option: -$OPTARG" >&2
+			exit 1
+			;;
+	esac
+done
+shift $((OPTIND-1))
+
+if [ $# != 2 ]; then
+	echo "Expected two parameters. Run '$COMMAND -h' for help." >&2
+	exit 1
+fi
+
+if [ $(id -u) -ne 0 ]; then
+	echo "This utility needs to run as root"
+	exit 1
+fi
+
+username=$1
+password=$2
+
+# We can't do anything until PHP and MySQL are up and running
+wait_for_php
+wait_for_mysql
+
+# Now we can use 'occ maintenance:install'
+
+mysql_nextcloud_password="$(mysql_get_nextcloud_password)"
+if [ -n "$mysql_nextcloud_password" ]; then
+	occ maintenance:install \
+		--database="mysql" \
+		--database-name="nextcloud" \
+		--database-user="nextcloud" \
+		--database-host="localhost:$MYSQL_SOCKET" \
+		--database-pass="$mysql_nextcloud_password" \
+		--data-dir="$NEXTCLOUD_DATA_DIR" \
+		--admin-user="$username" \
+		--admin-pass="$password"
+fi

--- a/src/nextcloud/scripts/occ
+++ b/src/nextcloud/scripts/occ
@@ -1,6 +1,8 @@
 #!/bin/sh
 
+. $SNAP/utilities/mysql-utilities
 . $SNAP/utilities/php-utilities
+. $SNAP/utilities/redis-utilities
 . $SNAP/utilities/nextcloud-utilities
 
 if [ $(id -u) -ne 0 ]; then
@@ -10,5 +12,6 @@ fi
 
 # occ can't do much before PHP FPM is up and running
 wait_for_php
+wait_for_nextcloud_to_be_configured
 
 php -c $SNAP/config/php $SNAP/htdocs/occ $*

--- a/src/nextcloud/utilities/nextcloud-utilities
+++ b/src/nextcloud/utilities/nextcloud-utilities
@@ -1,3 +1,20 @@
 #!/bin/sh
 
 export NEXTCLOUD_CONFIG_DIR=$SNAP_DATA/nextcloud/config
+export NEXTCLOUD_DATA_DIR=$SNAP_COMMON/nextcloud/data
+
+nextcloud_is_configured()
+{
+	[ -d "$NEXTCLOUD_CONFIG_DIR" ]
+}
+
+wait_for_nextcloud_to_be_configured()
+{
+	if ! nextcloud_is_configured; then
+		echo -n "Waiting for Nextcloud to be configured... "
+		while ! nextcloud_is_configured; do
+			sleep 1
+		done
+		echo "done"
+	fi
+}

--- a/src/php/scripts/start-php-fpm
+++ b/src/php/scripts/start-php-fpm
@@ -3,6 +3,7 @@
 . $SNAP/utilities/mysql-utilities
 . $SNAP/utilities/php-utilities
 . $SNAP/utilities/redis-utilities
+. $SNAP/utilities/nextcloud-utilities
 
 mkdir -p -m 750 ${SNAP_DATA}/php
 


### PR DESCRIPTION
This PR resolves #208 by adding a `manual-install` command that allows for the admin user to be created from the CLI instead of requiring one to use their browser.