### PR TITLE
mysql: fix socket location in root.ini.

### DIFF
--- a/src/mysql/start_mysql
+++ b/src/mysql/start_mysql
@@ -57,6 +57,11 @@ SQL
 
 	# Now the root mysql user has a password. Save that as well.
 	echo "password=$root_password" >> $root_option_file
+else
+	# Okay, this isn't a new installation. However, we recently changed
+	# the location of MySQL's socket (11.0.2snap1). Make sure the root
+	# option file is updated to look there instead of the old location.
+	sed -ri "s|(socket\s*=\s*)/var/snap/.*mysql.sock|\1$MYSQL_SOCKET|" $root_option_file
 fi
 
 # Wait here until mysql is running

--- a/src/nextcloud/scripts/setup_nextcloud
+++ b/src/nextcloud/scripts/setup_nextcloud
@@ -26,8 +26,12 @@ else
 	# This is not a new installation, so we don't want to overwrite the config.
 	# However, we recently changed the location of sockets in the snap, so we
 	# need to make sure the config is using the new location.
-	sed -ri "s|('host'\s*=>\s*)'/var/snap/nextcloud/.*redis.sock'|\1'$REDIS_SOCKET'|" $NEXTCLOUD_CONFIG_DIR/config.php
-	sed -ri "s|('dbhost'\s*=>\s*)'localhost:/var/snap/nextcloud/.*mysql.sock'|\1'localhost:$MYSQL_SOCKET'|" $NEXTCLOUD_CONFIG_DIR/config.php
+	sed -ri "s|('host'\s*=>\s*)'/var/snap/.*redis.sock'|\1'$REDIS_SOCKET'|" $NEXTCLOUD_CONFIG_DIR/config.php
+	sed -ri "s|('dbhost'\s*=>\s*)'localhost:/var/snap/.*mysql.sock'|\1'localhost:$MYSQL_SOCKET'|" $NEXTCLOUD_CONFIG_DIR/config.php
+
+	# We'll also always copy over the autoconfig.php, since it's only used
+	# upon installation. Just in case they haven't done that yet.
+	cp -r $SNAP/htdocs/config/autoconfig.php $NEXTCLOUD_CONFIG_DIR/
 
 	# Also make sure we're using Redis for the memcache and file locking.
 	occ config:system:set redis host --value="$REDIS_SOCKET" --type=string


### PR DESCRIPTION
In v11.0.2snap1, the location of the sockets in the snap changed to be in `/tmp`. However, it neglected to migrate the socket path specified in MySQL's `root.ini`, which is used by the MySQL client.

This PR fixes #228 by fixing that path.