### PR TITLE
CI: make daily builds use snap/snapcraft.yaml

### DIFF
--- a/.travis/cron.sh
+++ b/.travis/cron.sh
@@ -5,8 +5,8 @@ latest_stable_url="https://download.nextcloud.com/server/daily/latest-stable11.t
 
 rewrite_snapcraft_yaml()
 {
-	sed -ri "s|(source:\s+).*download.nextcloud.com.*$|\1$1|" snapcraft.yaml
-	sed -ri "s|(^version:\s+).*$|\1$2|" snapcraft.yaml
+	sed -ri "s|(source:\s+).*download.nextcloud.com.*$|\1$1|" snap/snapcraft.yaml
+	sed -ri "s|(^version:\s+).*$|\1$2|" snap/snapcraft.yaml
 }
 
 echo "Requesting build of latest master..."


### PR DESCRIPTION
This PR fixes #239 by making daily builds use `snap/snapcraft.yaml`. Without this, daily builds are unable to modify the YAML and end up just being normal releases.