### PR TITLE
apache: disable HTTP methods TRACE and TRACK

### DIFF
--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -180,6 +180,14 @@ LogLevel warn
 #
 TypesConfig conf/mime.types
 
+# Disable HTTP TRACE method.
+TraceEnable off
+
+# Disable HTTP TRACK method.
+RewriteEngine On
+RewriteCond %{REQUEST_METHOD} ^TRACK
+RewriteRule .* - [R=405,L]
+
 # Only enable SSL if requested
 <IfDefine EnableHTTPS>
     Include ${SNAP}/conf/ssl.conf

--- a/src/apache/conf/ssl.conf
+++ b/src/apache/conf/ssl.conf
@@ -74,11 +74,20 @@ SSLRandomSeed connect file:/dev/urandom 512
 # Virtual host for HTTP. All it does it redirect to HTTPS.
 <VirtualHost *:80>
     RewriteEngine on
+    # Disable HTTP TRACK method.
+    RewriteCond %{REQUEST_METHOD} ^TRACK
+    RewriteRule .* - [R=405,L]
+    # Redirect everything else to HTTPS
     RewriteRule ^ https://%{SERVER_NAME}%{REQUEST_URI} [END,QSA,R=permanent]
 </VirtualHost>
 
 # Virtual host for HTTPS.
 <VirtualHost *:443>
+
+    # Disable HTTP TRACK method.
+    RewriteEngine On
+    RewriteCond %{REQUEST_METHOD} ^TRACK
+    RewriteRule .* - [R=405,L]
 
     SSLEngine on
     SSLHonorCipherOrder On


### PR DESCRIPTION
TRACE and TRACK are HTTP debugging methods, and it has been shown that they can be used for cross-site-scripting attacks. These methods are not necessary for a properly-functioning Nextcloud install, so this PR resolves #250 by disabling them.