### PR TITLE
Remove weak 3DES SSL algorithms

### DIFF
--- a/src/apache/conf/ssl.conf
+++ b/src/apache/conf/ssl.conf
@@ -91,7 +91,7 @@ SSLRandomSeed connect file:/dev/urandom 512
 
     SSLEngine on
     SSLHonorCipherOrder On
-    SSLCipherSuite ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS;
+    SSLCipherSuite ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS;
 
     SSLCertificateFile      ${SNAP_DATA}/certs/live/cert.pem
     SSLCertificateKeyFile   ${SNAP_DATA}/certs/live/privkey.pem


### PR DESCRIPTION
This PR resolves #258 by disabling 3DES SSL algorithms, which were reported by both Nessus and SSL Labs to be weak.