### PR TITLE
Add samba client support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -146,6 +146,15 @@ parts:
     prime:
       - -htdocs/apps/updatenotification
 
+  # libsmbclient is needed by the SMB PHP module but it depends upon python.
+  # Pulling in python via stage-packages conflicts with the python from the
+  # python plugin used in certbot, so we'll use the python plugin too to
+  # install libsmbclient.
+  libsmbclient:
+    plugin: python
+    python-version: python2
+    stage-packages: [libsmbclient]
+
   php:
     plugin: php
     source: http://us1.php.net/get/php-7.0.18.tar.bz2/from/this/mirror
@@ -182,6 +191,7 @@ parts:
       - libjpeg9-dev
       - libbz2-dev
       - libmcrypt-dev
+      - libsmbclient-dev
     prime:
      - -sbin/
      - -etc/
@@ -192,6 +202,9 @@ parts:
       # Build the redis PHP module
       - source: https://github.com/phpredis/phpredis.git
         source-branch: php7
+      # Build the php-smbclient module
+      - source: https://github.com/eduardok/libsmbclient-php.git
+        source-tag: 0.9.0
 
   redis:
     plugin: redis

--- a/src/php/config/php.ini
+++ b/src/php/config/php.ini
@@ -901,6 +901,7 @@ default_socket_timeout = 60
 ;extension=php_xsl.dll
 
 extension=redis.so
+extension=smbclient.so
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;


### PR DESCRIPTION
This tries to fix https://github.com/nextcloud/nextcloud-snap/issues/60.

I added libsmbclient from the repos and php-libsmb as a php extension, but when trying to create the snap I get this error:

```
Parts 'certbot-nextcloud-plugin' and 'php' have the following file paths in common which have different contents:
    6/5/17 10:046/5/17 10:04usr/bin/2to3-2.7
    usr/bin/pydoc2.7
    usr/lib/python2.7/UserString.py
    usr/lib/python2.7/base64.py
    usr/lib/python2.7/cProfile.py
    usr/lib/python2.7/cgi.py
    usr/lib/python2.7/encodings/rot_13.py
    usr/lib/python2.7/ensurepip/__init__.py
    usr/lib/python2.7/keyword.py
    usr/lib/python2.7/lib2to3/pgen2/token.py
    usr/lib/python2.7/mimify.py
    usr/lib/python2.7/pdb.py
    usr/lib/python2.7/platform.py
    usr/lib/python2.7/profile.py
    usr/lib/python2.7/pydoc.py
    usr/lib/python2.7/quopri.py
    usr/lib/python2.7/sitecustomize.py
    usr/lib/python2.7/smtpd.py
    usr/lib/python2.7/smtplib.py
    usr/lib/python2.7/symbol.py
    usr/lib/python2.7/tabnanny.py
    usr/lib/python2.7/test/pystone.py
    usr/lib/python2.7/test/regrtest.py
    usr/lib/python2.7/timeit.py
    usr/lib/python2.7/trace.py
    usr/lib/python2.7/uu.py
    usr/lib/python2.7/webbrowser.py
    usr/share/python/dh_python2
    usr/share/python/pyversions.py

Snapcraft offers some capabilities to solve this by use of the following keywords:
    - `filesets`
    - `stage`
    - `snap`
    - `organize`

Learn more about these part keywords by running `snapcraft help plugins`
```

It's complaining because the shebang of the python2.7 files that come from the repository (because libsmbclient has python2.7 as one of it's dependencies) have a different shebang from the one that comes with the files from the snapcraft python plugin (for the cerbot-nextcloud-plugin part):

```
ubuntu@nextcloud-snap-compile:~/snaps/nextcloud-snap$ diff ./parts/certbot-nextcloud-plugin/install/usr/lib/python2.7/UserString.py ./parts/php/install/usr/lib/python2.7/UserString.py
1c1
< #!/usr/bin/env python2.7
---
> #! /usr/bin/python2.7
ubuntu@nextcloud-snap-compile:~/snaps/nextcloud-snap$ diff ./parts/certbot-nextcloud-plugin/install/usr/lib/python2.7/smtplib.py ./parts/php/install/usr/lib/python2.7/smtplib.py
1c1
< #!/usr/bin/env python2.7
---
> #! /usr/bin/python2.7
ubuntu@nextcloud-snap-compile:~/snaps/nextcloud-snap$ diff ./parts/certbot-nextcloud-plugin/install/usr/lib/python2.7/tabnanny.py ./parts/php/install/usr/lib/python2.7/tabnanny.py
1c1
< #!/usr/bin/env python2.7
---
> #! /usr/bin/python2.7
```
And I think that it's related to this replace:
- https://github.com/snapcore/snapcraft/blob/master/snapcraft/plugins/python.py#L351

I've tried to remove the conflicting files in the "prime" stage of php but didn't work.

Any ideas? Should we open a bug in snapcraft?