### PR TITLE
apache: support changing ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,36 @@ logged in and able to create users, install apps, and upload files.
 Note that this snap includes a service that runs cron.php every 15 minutes,
 which will automatically change the cron admin setting to Cron for you.
 
+
+### Removable media
+
 Also note that the interface providing the ability to access removable media is
 not automatically connected upon install, so if you'd like to use external
 storage (or otherwise use a device in `/media` for data), you need to give the
 snap permission to access removable media by connecting that interface:
 
     $ sudo snap connect nextcloud:removable-media
+
+
+### HTTP/HTTPS port configuration
+
+By default, the snap will listen on port 80. If you enable HTTPS, it will listen
+on both 80 and 443, and HTTP traffic will be redirected to HTTPS. But perhaps
+you're putting the snap behind a proxy of some kind, in which case you probably
+want to change those ports.
+
+If you'd like to change the HTTP port (say, to port 81), run:
+
+    $ sudo snap set nextcloud ports.http=81
+
+To change the HTTPS port (say, to port 444), run:
+
+    $ sudo snap set nextcloud ports.https=444
+
+Note that, assuming HTTPS is enabled, this will cause HTTP traffic to be
+redirected to port 444. You can specify both of these simultaneously as well:
+
+    $ sudo snap set nextcloud ports.http=81 ports.https=444
 
 
 ### Included CLI utilities

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -85,6 +85,10 @@ apps:
     command: manual-install
     plugs: [network, network-bind, removable-media]
 
+hooks:
+  configure:
+    plugs: [network, network-bind]
+
 parts:
   apache:
     plugin: apache
@@ -325,3 +329,9 @@ parts:
     stage-packages: [openssl]
     stage: [-etc/ssl]
     prime: [-etc/ssl]
+
+  hooks:
+    plugin: dump
+    source: src/hooks
+    organize:
+      '*': snap/hooks/

--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -18,7 +18,7 @@ ServerRoot "${SNAP}"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-Listen 80
+Listen ${HTTP_PORT}
 
 #
 # Mutex: Allows you to set the mutex mechanism and mutex file directory

--- a/src/apache/conf/ssl.conf
+++ b/src/apache/conf/ssl.conf
@@ -7,7 +7,7 @@
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-Listen 443
+Listen ${HTTPS_PORT}
 
 #
 # Dynamic Shared Object (DSO) Support
@@ -72,17 +72,17 @@ SSLRandomSeed connect builtin
 SSLRandomSeed connect file:/dev/urandom 512
 
 # Virtual host for HTTP. All it does it redirect to HTTPS.
-<VirtualHost *:80>
+<VirtualHost *:${HTTP_PORT}>
     RewriteEngine on
     # Disable HTTP TRACK method.
     RewriteCond %{REQUEST_METHOD} ^TRACK
     RewriteRule .* - [R=405,L]
     # Redirect everything else to HTTPS
-    RewriteRule ^ https://%{SERVER_NAME}%{REQUEST_URI} [END,QSA,R=permanent]
+    RewriteRule ^ https://%{SERVER_NAME}:${HTTPS_PORT}%{REQUEST_URI} [END,QSA,R=permanent]
 </VirtualHost>
 
 # Virtual host for HTTPS.
-<VirtualHost *:443>
+<VirtualHost *:${HTTPS_PORT}>
 
     # Disable HTTP TRACK method.
     RewriteEngine On

--- a/src/apache/scripts/httpd-wrapper
+++ b/src/apache/scripts/httpd-wrapper
@@ -20,4 +20,7 @@ else
 	echo "No certificates are active: using HTTP only"
 fi
 
+export HTTP_PORT="$(apache_http_port)"
+export HTTPS_PORT="$(apache_https_port)"
+
 httpd -d $SNAP $params $@

--- a/src/apache/utilities/apache-utilities
+++ b/src/apache/utilities/apache-utilities
@@ -1,24 +1,83 @@
 #!/bin/sh
 
+APACHE_HTTP_PORT_FILE="$SNAP_DATA/apache/data/http_port"
+APACHE_HTTPS_PORT_FILE="$SNAP_DATA/apache/data/https_port"
 export APACHE_PIDFILE="/tmp/pids/httpd.pid"
 
+mkdir -p -m 750 "$(dirname $APACHE_HTTP_PORT_FILE)"
+mkdir -p -m 750 "$(dirname $APACHE_HTTPS_PORT_FILE)"
 mkdir -p -m 750 "$(dirname $APACHE_PIDFILE)"
 
 restart_apache_if_running()
 {
-	if [ -f "$APACHE_PIDFILE" ]; then
+	if apache_is_running; then
 		# Restart apache by stopping it and letting systemd start it again.
-		apache_pid=$(cat "$APACHE_PIDFILE")
+		pid="$(apache_pid)"
 		echo -n "Restarting apache... "
 		output=$(httpd-wrapper -k stop 2>&1)
 		if [ $? -eq 0 ]; then
-			while kill -0 $apache_pid 2>/dev/null; do
+			while kill -0 $pid 2>/dev/null; do
 				sleep 1
 			done
 			echo "done"
 		else
 			echo "error"
 			echo "$output"
+			return 1
 		fi
 	fi
+}
+
+apache_is_running()
+{
+	[ -f "$APACHE_PIDFILE" ]
+}
+
+wait_for_apache()
+{
+	if ! apache_is_running; then
+		echo -n "Waiting for Apache... "
+		while ! apache_is_running; do
+			sleep 1
+		done
+		echo "done"
+	fi
+}
+
+apache_pid()
+{
+	if apache_is_running; then
+		cat "$APACHE_PIDFILE"
+	else
+		echo "Unable to get Apache PID as it's not yet running" >&2
+		echo ""
+	fi
+}
+
+apache_http_port()
+{
+	if [ ! -f "$APACHE_HTTP_PORT_FILE" ]; then
+		apache_set_http_port "80"
+	fi
+
+	cat "$APACHE_HTTP_PORT_FILE"
+}
+
+apache_set_http_port()
+{
+	echo "$1" > "$APACHE_HTTP_PORT_FILE"
+}
+
+apache_https_port()
+{
+	if [ ! -f "$APACHE_HTTPS_PORT_FILE" ]; then
+		apache_set_https_port "443"
+	fi
+
+	cat "$APACHE_HTTPS_PORT_FILE"
+}
+
+apache_set_https_port()
+{
+	echo "$1" > "$APACHE_HTTPS_PORT_FILE"
 }

--- a/src/hooks/configure
+++ b/src/hooks/configure
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+# Supported keys:
+# - ports.http (integer)
+#   Port on which the snap will listen for HTTP traffic.
+#
+# - ports.https (integer)
+#   Port on which the snap will listen for HTTPS traffic (only applies if HTTPS
+#   is enabled).
+
+. $SNAP/utilities/apache-utilities
+
+handle_apache_port_config()
+{
+	old_http_port="$(apache_http_port)"
+	old_https_port="$(apache_https_port)"
+
+	http_port="$(snapctl get ports.http)"
+	if [ -z "$http_port" ]; then
+		http_port="$old_http_port"
+		snapctl set ports.http="$http_port"
+	fi
+
+	https_port="$(snapctl get ports.https)"
+	if [ -z "$https_port" ]; then
+		https_port="$old_https_port"
+		snapctl set ports.https="$https_port"
+	fi
+
+	# If no changes were requested, then there's nothing to do here.
+	if [ "$http_port" = "$old_http_port" -a "$https_port" = "$old_https_port" ]; then
+		return 0
+	fi
+
+	# Validate HTTP port
+	if ! expr "$http_port" : '^[0-9]*$' > /dev/null; then
+		echo "\"$http_port\" is not a valid HTTP port" >&2
+		return 1
+	fi
+
+	# Validate HTTPS port
+	if ! expr "$https_port" : '^[0-9]*$' > /dev/null; then
+		echo "\"$https_port\" is not a valid HTTPS port" >&2
+		return 2
+	fi
+
+	apache_set_http_port "$http_port"
+	apache_set_https_port "$https_port"
+
+	# If restarting ran into problems, revert the change before erroring out.
+	if ! restart_apache_if_running; then
+		apache_set_http_port "$old_http_port"
+		apache_set_https_port "$old_https_port"
+		restart_apache_if_running
+		return 3
+	fi
+}
+
+handle_apache_port_config


### PR DESCRIPTION
Currently, Apache listens on port 80. If HTTPS is enabled, it listens on both 80 and 443. This is inflexible, especially if one wants to put the snap behind a proxy of some kind.

This PR fixes #134 by adding support for changing HTTP and HTTPS ports via the `configure` hook. It exposes these configurations via the `ports.http` and `ports.https` options, respectively.

## Testing

To test this, please install one of the following snaps via `sudo snap install --dangerous <snap>` and follow the documentation added in this PR to the README:

- [amd64](https://code.launchpad.net/~kyrofa/+snap/nextcloud-test/+build/37279/+files/nextcloud_11.0.3snap1_amd64.snap)
- [i386](https://code.launchpad.net/~kyrofa/+snap/nextcloud-test/+build/37282/+files/nextcloud_11.0.3snap1_i386.snap)
- [armhf](https://code.launchpad.net/~kyrofa/+snap/nextcloud-test/+build/37281/+files/nextcloud_11.0.3snap1_armhf.snap)
- [arm64](https://code.launchpad.net/~kyrofa/+snap/nextcloud-test/+build/37280/+files/nextcloud_11.0.3snap1_arm64.snap)
- [ppc64el](https://code.launchpad.net/~kyrofa/+snap/nextcloud-test/+build/37283/+files/nextcloud_11.0.3snap1_ppc64el.snap)

### Things to test:

- Verify that neither port option accepts non-numeric values
- Verify that setting `ports.http=81` immediately restarts Apache and Nextcloud is now available on port 81 (and **not** 80).
- Verify that setting `ports.https=444` immediately restarts Apache, but doesn't enable HTTPS if it isn't already enabled. If HTTPS is enabled, Nextcloud should now be available on port 444 (and **not** 443).
- Verify that, even when the ports are non-standard, if HTTPS is enabled, the HTTP port should always redirect to HTTPS (e.g. port 81 should redirect to port 444).