### PR TITLE
Add samba client support.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -150,6 +150,15 @@ parts:
     prime:
       - -htdocs/apps/updatenotification
 
+  # libsmbclient is needed by the SMB PHP module but it depends upon python.
+  # Pulling in python via stage-packages conflicts with the python from the
+  # python plugin used in certbot, so we'll use the python plugin too to
+  # install libsmbclient.
+  libsmbclient:
+    plugin: python
+    python-version: python2
+    stage-packages: [libsmbclient]
+
   php:
     plugin: php
     source: http://us1.php.net/get/php-7.0.18.tar.bz2/from/this/mirror
@@ -186,6 +195,7 @@ parts:
       - libjpeg9-dev
       - libbz2-dev
       - libmcrypt-dev
+      - libsmbclient-dev
     prime:
      - -sbin/
      - -etc/
@@ -196,6 +206,9 @@ parts:
       # Build the redis PHP module
       - source: https://github.com/phpredis/phpredis.git
         source-branch: php7
+      # Build the php-smbclient module
+      - source: https://github.com/eduardok/libsmbclient-php.git
+        source-tag: 0.9.0
 
   redis:
     plugin: redis

--- a/src/php/config/php.ini
+++ b/src/php/config/php.ini
@@ -901,6 +901,7 @@ default_socket_timeout = 60
 ;extension=php_xsl.dll
 
 extension=redis.so
+extension=smbclient.so
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;


### PR DESCRIPTION
Fixes #60 by adding libsmbclient-php and libsmbclient. **Note:** We had to install libsmbclient from the python plugin, as it's python dependency conflicted with the python pulled by the certbot part when directly staged. See LP: [#1630996](https://bugs.launchpad.net/snapcraft/+bug/1630996) for more information.