### PR TITLE
Revert "Add samba client support."

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -150,15 +150,6 @@ parts:
     prime:
       - -htdocs/apps/updatenotification
 
-  # libsmbclient is needed by the SMB PHP module but it depends upon python.
-  # Pulling in python via stage-packages conflicts with the python from the
-  # python plugin used in certbot, so we'll use the python plugin too to
-  # install libsmbclient.
-  libsmbclient:
-    plugin: python
-    python-version: python2
-    stage-packages: [libsmbclient]
-
   php:
     plugin: php
     source: http://us1.php.net/get/php-7.0.18.tar.bz2/from/this/mirror
@@ -195,7 +186,6 @@ parts:
       - libjpeg9-dev
       - libbz2-dev
       - libmcrypt-dev
-      - libsmbclient-dev
     prime:
      - -sbin/
      - -etc/
@@ -206,9 +196,6 @@ parts:
       # Build the redis PHP module
       - source: https://github.com/phpredis/phpredis.git
         source-branch: php7
-      # Build the php-smbclient module
-      - source: https://github.com/eduardok/libsmbclient-php.git
-        source-tag: 0.9.0
 
   redis:
     plugin: redis

--- a/src/php/config/php.ini
+++ b/src/php/config/php.ini
@@ -901,7 +901,6 @@ default_socket_timeout = 60
 ;extension=php_xsl.dll
 
 extension=redis.so
-extension=smbclient.so
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;


### PR DESCRIPTION
This PR re-breaks #60 by reverting commit 9acd46f314cc036bd06aa8a74365ef847cd6623b (PR #271). It doesn't work on armhf (and potentially other architectures), and seems to also break webdav on armhf.

@pachulo, please feel free to debug this further and re-propose if you manage to figure out what's going on.