### PR TITLE
mysql: update to 5.7.18

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -237,7 +237,7 @@ parts:
     plugin: cmake
     source: https://github.com/kyrofa/mysql-server.git
     source-type: git
-    source-branch: feature/support_no_setpriority
+    source-branch: mysql-5.7.18_support_no_setpriority
     after: [boost]
     configflags:
       - -DWITH_BOOST=$SNAPCRAFT_STAGE/boost


### PR DESCRIPTION
This PR resolves #94 by updating MySQL to the latest 5.7.18 release.

In order to test this PR, run:

```
$ sudo snap install nextcloud --channel=stable/pr-283
```

We need to make sure we test upgrades particularly well (e.g. install the snap from stable, upload some files, add users, add contacts/calendars, etc. Then `sudo snap refresh nextcloud --channel=stable/pr-283`). The snap has code to run the mysql upgrade commands, but this will be our first actual mysql upgrade, so it hasn't gotten much (any) exercise.