### PR TITLE
php: update to 7.0.19

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -148,8 +148,8 @@ parts:
 
   php:
     plugin: php
-    source: http://us1.php.net/get/php-7.0.18.tar.bz2/from/this/mirror
-    source-checksum: sha256/b20cc63d507032b39d8bb14cb64784e460b0e47997e90a8704b703bcbb233fd1
+    source: http://us1.php.net/get/php-7.0.19.tar.bz2/from/this/mirror
+    source-checksum: sha256/0f3ac0afc02aec22f6b1659045da9287453e9309439d0499622bc8e94a7f7d59
     source-type: tar
     install-via: prefix
     configflags:


### PR DESCRIPTION
This PR resolves #290 by updating PHP from 7.0.18, which has multiple security vulnerabilities, to 7.0.19.

Please test this PR with:

    $ sudo snap install --channel=stable/pr-291 nextcloud