### PR TITLE
apache: update to 2.4.26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
          command: |
            sudo apt update
            sudo apt install -y snapd
-           docker run -v $(pwd):$(pwd) -t ubuntu:xenial sh -c "apt update -qq && apt install snapcraft -y && cd $(pwd) && snapcraft"
+           docker run -v $(pwd):$(pwd) -e LC_ALL=C.UTF-8 -e LANG=C.UTF-8 -t ubuntu:xenial sh -c "apt update -qq && apt install snapcraft -y && cd $(pwd) && snapcraft"
      - run:
          command: |
            sudo snap install *.snap --dangerous

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -88,8 +88,8 @@ apps:
 parts:
   apache:
     plugin: apache
-    source: http://ftp.wayne.edu/apache/httpd/httpd-2.4.25.tar.bz2
-    source-checksum: sha1/bd6d138c31c109297da2346c6e7b93b9283993d2
+    source: http://ftp.wayne.edu/apache/httpd/httpd-2.4.26.tar.bz2
+    source-checksum: sha1/b10b0f569a0e5adfef61d8c7f0813d42046e399a
 
     # The built-in Apache modules to enable
     modules:

--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -154,6 +154,7 @@ Alias "/.well-known/acme-challenge" "${SNAP_DATA}/certs/certbot/.well-known/acme
 
 # Setup the proxy to PHP-FPM
 ProxyTimeout 3600
+ProxyFCGIBackendType GENERIC
 <FilesMatch \.php$>
     SetHandler "proxy:unix:${PHP_FPM_SOCKET}|fcgi://localhost/"
 </FilesMatch>


### PR DESCRIPTION
This PR resolves #311 by updating Apache from 2.4.25 to 2.4.26.

Please test this PR by installing the snap from the `stable/pr-312` branch:

    $ sudo snap install nextcloud --channel=stable/pr-312

Or if you already have it installed:

    $ sudo snap refresh nextcloud --channel=stable/pr-312