### PR TITLE
mdns-publisher: use godeps to manage dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 prime/
 stage/
 .travis/deploy_key
+snap/.snapcraft/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -302,8 +302,9 @@ parts:
       src/mysql/utilities/*: utilities/
 
   mdns-publisher:
-    plugin: go
-    go-packages: [github.com/kyrofa/mdns-publisher]
+    plugin: godeps
+    source: https://github.com/kyrofa/mdns-publisher.git
+    go-importpath: github.com/kyrofa/mdns-publisher
 
   delay-on-failure:
     plugin: copy


### PR DESCRIPTION
This PR resolves #317 by using the godeps `dependencies.tsv` file contained within mdns-publisher to manage its dependencies.