### PR TITLE
apache: update to 2.4.27

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -88,8 +88,8 @@ apps:
 parts:
   apache:
     plugin: apache
-    source: http://ftp.wayne.edu/apache/httpd/httpd-2.4.26.tar.bz2
-    source-checksum: sha1/b10b0f569a0e5adfef61d8c7f0813d42046e399a
+    source: http://ftp.wayne.edu/apache/httpd/httpd-2.4.27.tar.bz2
+    source-checksum: sha256/71fcc128238a690515bd8174d5330a5309161ef314a326ae45c7c15ed139c13a
 
     # The built-in Apache modules to enable
     modules:


### PR DESCRIPTION
This PR resolves #319 by updating Apache to v2.4.27. Is also changes the checksum to use sha256 instead of SHA1.

To test this PR, install from the `stable/pr-320` channel:

    $ sudo snap install nextcloud --channel=stable/pr-320

If you already have it installed:

    $ sudo snap refresh nextcloud --channel=stable/pr-320