### PR TITLE
nextcloud: update to 11.0.4

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -134,8 +134,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-11.0.3.tar.bz2
-    source-checksum: sha256/28d5ee39f31c6be20f037ad2eb300272ad9bb72a7d428eb0152c7a3fde87d545
+    source: https://download.nextcloud.com/server/releases/nextcloud-11.0.4.tar.bz2
+    source-checksum: sha256/68b89f1d0068728f76d89519c7d0a57396f2d216d048cc970346d436ec61999e
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
Nextcloud v12 is pretty buggy. This PR resolves #335 by updating the snap to v11.0.4 while we're trying to stabilize. Please test this PR by using the `stable/pr-338` channel:

    $ sudo snap install nextcloud --channel=stable/pr-338

Or if you already have it installed:

    $ sudo snap refresh nextcloud --channel=stable/pr-338