### PR TITLE
nextcloud: update to v11.0.5

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -138,8 +138,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-11.0.4.tar.bz2
-    source-checksum: sha256/68b89f1d0068728f76d89519c7d0a57396f2d216d048cc970346d436ec61999e
+    source: https://download.nextcloud.com/server/releases/nextcloud-11.0.5.tar.bz2
+    source-checksum: sha256/47261211384e63b1d4816be60817b0315029d018b5568ac3aeb3181be5fb98a4
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #357 by updating Nextcloud to v11.0.5.

In order to test this, please use the `stable/pr-360` channel:

    sudo snap install nextcloud --channel=stable/pr-360

If already installed:

    sudo snap refresh nextcloud --channel=stable/pr-360