### PR TITLE
redis: update to 4.0.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -195,12 +195,12 @@ parts:
     extensions:
       # Build the redis PHP module
       - source: https://github.com/phpredis/phpredis.git
-        source-branch: php7
+        source-tag: 3.1.4
 
   redis:
     plugin: redis
-    source: http://download.redis.io/releases/redis-3.2.8.tar.gz
-    source-checksum: sha1/6780d1abb66f33a97aad0edbe020403d0a15b67f
+    source: http://download.redis.io/releases/redis-4.0.2.tar.gz
+    source-checksum: sha256/b1a0915dbc91b979d06df1977fe594c3fa9b189f1f3d38743a2948c9f7634813
 
   redis-customizations:
     plugin: copy


### PR DESCRIPTION
This PR fixes #361 by both updating Redis to 4.0.2 and using v3.1.4 of the PHP module.

To test this PR, use the `stable/pr-362` channel:

    $ sudo snap install nextcloud --channel=stable/pr-362

Or, if you already have it installed:

    $ sudo refresh nextcloud --channel=stable/pr-362