### PR TITLE
phpredis: use 3.1.4 tarball and checksum

### DIFF
--- a/snap/plugins/x-php.py
+++ b/snap/plugins/x-php.py
@@ -43,6 +43,9 @@ class PhpPlugin(autotools.AutotoolsPlugin):
                     'source-subdir': {
                         'type': 'string'
                     },
+                    'source-checksum': {
+                        'type': 'string'
+                    },
                     'configflags': {
                         'type': 'array',
                         'minitems': 1,

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -194,8 +194,8 @@ parts:
       sbin/php-fpm: bin/php-fpm
     extensions:
       # Build the redis PHP module
-      - source: https://github.com/phpredis/phpredis.git
-        source-tag: 3.1.4
+      - source: https://github.com/phpredis/phpredis/archive/3.1.4.tar.gz
+        source-checksum: sha256/656cab2eb93bd30f30701c1280707c60e5736c5420212d5d547ebe0d3f4baf71
 
   redis:
     plugin: redis


### PR DESCRIPTION
The tag somehow changed such that the version was `develop` instead of `3.1.4`. This PR 
fixes #370 by using the tarball and making sure it can't change without us noticing by verifying the checksum.