### PR TITLE
apache: update to 2.4.28

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -92,8 +92,8 @@ hooks:
 parts:
   apache:
     plugin: apache
-    source: http://ftp.wayne.edu/apache/httpd/httpd-2.4.27.tar.bz2
-    source-checksum: sha256/71fcc128238a690515bd8174d5330a5309161ef314a326ae45c7c15ed139c13a
+    source: http://ftp.wayne.edu/apache/httpd/httpd-2.4.28.tar.bz2
+    source-checksum: sha256/c1197a3a62a4ab5c584ab89b249af38cf28b4adee9c0106b62999fd29f920666
 
     # The built-in Apache modules to enable
     modules:


### PR DESCRIPTION
This PR fixes #372 by upgrading Apache from v2.4.27 to v2.4.28.