### PR TITLE
nextcloud: update to 12.0.4

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -138,8 +138,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-11.0.5.tar.bz2
-    source-checksum: sha256/47261211384e63b1d4816be60817b0315029d018b5568ac3aeb3181be5fb98a4
+    source: https://download.nextcloud.com/server/releases/nextcloud-12.0.4.tar.bz2
+    source-checksum: sha256/654161a74ceaf9a60c7731d7d6702e6710a972633a97955d16f01abeb09d09b6
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess

--- a/src/php/config/php.ini
+++ b/src/php/config/php.ini
@@ -1732,21 +1732,23 @@ ldap.max_links = -1
 ;dba.default_handler=
 
 [opcache]
+zend_extension=opcache.so
+
 ; Determines if Zend OPCache is enabled
-;opcache.enable=0
+opcache.enable=1
 
 ; Determines if Zend OPCache is enabled for the CLI version of PHP
-;opcache.enable_cli=0
+opcache.enable_cli=1
 
 ; The OPcache shared memory storage size.
-;opcache.memory_consumption=64
+opcache.memory_consumption=128
 
 ; The amount of memory for interned strings in Mbytes.
-;opcache.interned_strings_buffer=4
+opcache.interned_strings_buffer=8
 
 ; The maximum number of keys (scripts) in the OPcache hash table.
 ; Only numbers between 200 and 100000 are allowed.
-;opcache.max_accelerated_files=2000
+opcache.max_accelerated_files=10000
 
 ; The maximum percentage of "wasted" memory until a restart is scheduled.
 ;opcache.max_wasted_percentage=5
@@ -1759,19 +1761,19 @@ ldap.max_links = -1
 
 ; When disabled, you must reset the OPcache manually or restart the
 ; webserver for changes to the filesystem to take effect.
-;opcache.validate_timestamps=1
+opcache.validate_timestamps=0
 
 ; How often (in seconds) to check file timestamps for changes to the shared
 ; memory storage allocation. ("1" means validate once per second, but only
 ; once per request. "0" means always validate)
-;opcache.revalidate_freq=2
+opcache.revalidate_freq=1
 
 ; Enables or disables file search in include_path optimization
 ;opcache.revalidate_path=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=1
 
 ; If enabled, a fast shutdown sequence is used for the accelerated code
 ;opcache.fast_shutdown=0


### PR DESCRIPTION
All known blocking regressions in v12 have finally been fixed, so this PR resolves #280 by updating Nextcloud to v12.0.4. It also enables the opcache and tweaks the parameters as Nextcloud itself suggests.

Please test this PR using the `stable/pr-388` channel:

    $ sudo snap install nextcloud --channel=stable/pr-388

Or if you already have it installed (note that you can't go back if you do this, Nextcloud doesn't support downgrades!):

    $ sudo snap refresh nextcloud --channel=stable/pr-388

We need to particularly ensure that it works on a clean install as well as upgrades from the current stable. To anyone who _does not want to upgrade_ to v12, you don't have to, but you [need to take action](https://kyrofa.com/posts/nextcloud-snap-to-be-updated-to-v12).