### PR TITLE
php: enable pcntl

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -173,6 +173,7 @@ parts:
       - --with-mcrypt
       - --enable-exif
       - --enable-intl
+      - --enable-pcntl
       - --with-jpeg-dir=/usr/lib
       - --disable-rpath
     stage-packages:


### PR DESCRIPTION
This PR resolves #396, getting rid of warnings when using `occ`, which were annoying and often misled people into thinking something was wrong.

Please test this PR using the `stable/pr-397` channel:

    $ sudo snap install nextcloud --channel=stable/pr-397

Or if you already have it installed:

    $ sudo snap refresh nextcloud --channel=stable/pr-397