### PR TITLE
[11] nextcloud: update to 11.0.6

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -138,8 +138,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-11.0.5.tar.bz2
-    source-checksum: sha256/47261211384e63b1d4816be60817b0315029d018b5568ac3aeb3181be5fb98a4
+    source: https://download.nextcloud.com/server/releases/nextcloud-11.0.6.tar.bz2
+    source-checksum: sha256/f1581bd77143990172eb7cd2b2cfed3019a95c025643b9b3be48429b2075899a
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #389 by updating Nextcloud to v11.0.6.

Test this PR with the `11/stable/pr-403` channel:

    $ sudo snap install nextcloud --channel=11/stable/pr-403

If you already have it installed:

    $ sudo snap refresh nextcloud --channel=11/stable/pr-403