### PR TITLE
[11] php: enable pcntl

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -173,6 +173,7 @@ parts:
       - --with-mcrypt
       - --enable-exif
       - --enable-intl
+      - --enable-pcntl
       - --with-jpeg-dir=/usr/lib
       - --disable-rpath
     stage-packages:


### PR DESCRIPTION
This PR is a backport of #397, resolving #396 for 11 by getting rid of warnings when using `occ`, which were annoying and often misled people into thinking something was wrong.

Test this PR with the `11/stable/pr-404` channel:

    sudo snap install nextcloud --channel=11/stable/pr-404

Or if you already have it installed:

    sudo snap refresh nextcloud --channel=11/stable/pr-404