### PR TITLE
php: enable ldap support

### DIFF
--- a/snap/plugins/x-php.py
+++ b/snap/plugins/x-php.py
@@ -99,7 +99,19 @@ class PhpPlugin(autotools.AutotoolsPlugin):
         if os.path.exists(self.extensions_directory):
             shutil.rmtree(self.extensions_directory)
 
+    def _replace_arch_triplet(self):
+        pattern = re.compile(r'ARCH_TRIPLET')
+
+        old_configflags = self.options.configflags
+        self.options.configflags = []
+        for flag in old_configflags:
+            self.options.configflags.append(
+                pattern.sub(self.project.arch_triplet, flag))
+
     def build(self):
+        # Replace ARCH_TRIPLET in options
+        self._replace_arch_triplet()
+
         super().build()
 
         if self.extensions:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -176,6 +176,10 @@ parts:
       - --enable-pcntl
       - --with-jpeg-dir=/usr/lib
       - --disable-rpath
+
+      # Enable ldap.
+      - --with-libdir=lib/ARCH_TRIPLET
+      - --with-ldap
     stage-packages:
       # These are only included here until the OS snap stabilizes
       - libxml2
@@ -187,6 +191,7 @@ parts:
       - libjpeg9-dev
       - libbz2-dev
       - libmcrypt-dev
+      - libldap2-dev
     prime:
      - -sbin/
      - -etc/


### PR DESCRIPTION
- Enables the LDAP module in PHP, which allows the "LDAP user and group backend" app to be enabled