### PR TITLE
Configuration of Listen address implemented through hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ To change the listening address for the nextcloud snap, you run:
 
     $ sudo snap set nextcloud listen-address=127.0.0.1
 
+If you wish to have your nextcloud snap listening to the IPv6 loopback address, you would do:
+
+    $ sudo snap set nextcloud listen-address=::1
+
 
 #### HTTP/HTTPS port configuration
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ editing `/var/snap/nextcloud/current/nextcloud/config/config.php`), the snap
 exposes extra configuration options via the `snap set` command.
 
 
+#### Listen address configuration
+
+By default, the snap will listen on all IPv4 addresses (0.0.0.0) enabled on your system.
+If you wish to put your snap behind a reverse proxy, you can do so by e.g. configuring the snap
+to listen to the loopback interface at IP address 127.0.0.1 and then have the reverse proxy server
+forward all connections from the outside network to that IP address.
+
+To change the listening address for the nextcloud snap, you run:
+
+    $ sudo snap set nextcloud listen-address=127.0.0.1
+
+
 #### HTTP/HTTPS port configuration
 
 By default, the snap will listen on port 80. If you enable HTTPS, it will listen

--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -18,7 +18,8 @@ ServerRoot "${SNAP}"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-Listen ${HTTP_PORT}
+#Listen ${HTTP_PORT}
+Listen ${LISTEN_ADDRESS}:${HTTP_PORT}
 
 #
 # Mutex: Allows you to set the mutex mechanism and mutex file directory

--- a/src/apache/conf/ssl.conf
+++ b/src/apache/conf/ssl.conf
@@ -7,7 +7,8 @@
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-Listen ${HTTPS_PORT}
+#Listen ${HTTPS_PORT}
+Listen ${LISTEN_ADDRESS}:${HTTPS_PORT}
 
 #
 # Dynamic Shared Object (DSO) Support

--- a/src/apache/scripts/httpd-wrapper
+++ b/src/apache/scripts/httpd-wrapper
@@ -20,6 +20,13 @@ else
 	echo "No certificates are active: using HTTP only"
 fi
 
+# If no listen address is specified, listen on all IPv4 addresses (0.0.0.0)
+if [ $(apache_listen_address) ]; then
+    export LISTEN_ADDRESS="$(apache_listen_address)"
+else
+    export LISTEN_ADDRESS="0.0.0.0"
+fi
+
 export HTTP_PORT="$(apache_http_port)"
 export HTTPS_PORT="$(apache_https_port)"
 

--- a/src/apache/scripts/httpd-wrapper
+++ b/src/apache/scripts/httpd-wrapper
@@ -20,13 +20,7 @@ else
 	echo "No certificates are active: using HTTP only"
 fi
 
-# If no listen address is specified, listen on all IPv4 addresses (0.0.0.0)
-if [ $(apache_listen_address) ]; then
-    export LISTEN_ADDRESS="$(apache_listen_address)"
-else
-    export LISTEN_ADDRESS="0.0.0.0"
-fi
-
+export LISTEN_ADDRESS="$(apache_listen_address)"
 export HTTP_PORT="$(apache_http_port)"
 export HTTPS_PORT="$(apache_https_port)"
 

--- a/src/apache/utilities/apache-utilities
+++ b/src/apache/utilities/apache-utilities
@@ -52,6 +52,21 @@ apache_pid()
 	fi
 }
 
+apache_listen_address()
+{
+    address="$(snapctl get listen-address)"
+    if [ -z $address ]; then
+        address=""
+    else
+        echo "$address"
+    fi
+}
+
+apache_set_listen_address()
+{
+    snapctl set listen-address="$1"
+}
+
 apache_http_port()
 {
 	port="$(snapctl get ports.http)"

--- a/src/apache/utilities/apache-utilities
+++ b/src/apache/utilities/apache-utilities
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+DEFAULT_LISTEN_ADDRESS="0.0.0.0"
 DEFAULT_HTTP_PORT="80"
 DEFAULT_HTTPS_PORT="443"
 export APACHE_PIDFILE="/tmp/pids/httpd.pid"
@@ -56,15 +57,27 @@ apache_listen_address()
 {
     address="$(snapctl get listen-address)"
     if [ -z $address ]; then
-        address=""
-    else
-        echo "$address"
+        address="$DEFAULT_LISTEN_ADDRESS"
+        apache_set_listen_address $address
+        apache_set_previous_listen_address $address
     fi
+    
+    echo "$address"
 }
 
 apache_set_listen_address()
 {
     snapctl set listen-address="$1"
+}
+
+apache_previous_listen_address()
+{
+	echo "$(snapctl get private.listen-address)"
+}
+
+apache_set_previous_listen_address()
+{
+    snapctl set private.listen-address="$1"
 }
 
 apache_http_port()

--- a/src/hooks/bin/configure
+++ b/src/hooks/bin/configure
@@ -16,6 +16,33 @@
 . $SNAP/utilities/php-utilities
 . $SNAP/utilities/hook-utilities
 
+handle_apache_listen_address_config()
+{
+    listen_address="$(apache_listen_address)"
+    
+    # If no Listen address is submitted, then nothing to be done
+    if [ -z "$listen_address" ]; then
+        return 0
+    fi
+    
+    # Validate IP address using basic IPv4 regex
+    valid_ip4=$(echo $listen_address | awk -F"\." '$0 ~ /^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1 <=255 && $2 <= 255 && $3 <= 255 && $4 <= 254' 2>/dev/null)
+
+    # Validate IP address using basic IPv6 regex
+    #valid_ip6=$(echo $listen_address | awk '$0 ~ /^([0-9a-fA-F]{0,4}:){1,7}[0-9a-fA-F]{1,4}$/' 2>/dev/null)
+
+    if [ $valid_ip4 ];then
+        apache_set_listen_address "$listen_address"
+    else
+        echo "\"$listen_address\" is not a valid IP address" >&2
+        return 0
+    fi
+    
+    if ! restart_apache_if_running; then
+		return 6
+	fi
+}
+
 handle_apache_port_config()
 {
 	http_port="$(apache_http_port)"
@@ -40,6 +67,7 @@ handle_apache_port_config()
 		return 2
 	fi
 
+    
 	apache_set_http_port "$http_port"
 	apache_set_https_port "$https_port"
 
@@ -85,4 +113,4 @@ handle_php_memory_limit()
 set_configure_hook_running
 trap 'set_configure_hook_not_running' EXIT
 
-handle_apache_port_config && handle_php_memory_limit
+handle_apache_listen_address_config && handle_apache_port_config && handle_php_memory_limit

--- a/src/hooks/bin/configure
+++ b/src/hooks/bin/configure
@@ -19,9 +19,15 @@
 handle_apache_listen_address_config()
 {
     listen_address="$(apache_listen_address)"
+    previous_listen_address="(apache_previous_listen_address)"
     
     # If no Listen address is submitted, then nothing to be done
     if [ -z "$listen_address" ]; then
+        return 0
+    fi
+    
+    # If no changes were requested, then nothing to do here
+    if [ "$listen_address" = "$previous_listen_address"]; then
         return 0
     fi
     
@@ -29,10 +35,13 @@ handle_apache_listen_address_config()
     valid_ip4=$(echo $listen_address | awk -F"\." '$0 ~ /^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1 <=255 && $2 <= 255 && $3 <= 255 && $4 <= 254' 2>/dev/null)
 
     # Validate IP address using basic IPv6 regex
-    #valid_ip6=$(echo $listen_address | awk '$0 ~ /^([0-9a-fA-F]{0,4}:){1,7}[0-9a-fA-F]{1,4}$/' 2>/dev/null)
+    valid_ip6=$(echo $listen_address | awk '$0 ~ /^([0-9a-fA-F]{0,4}:){1,7}[0-9a-fA-F]{1,4}$/' 2>/dev/null)
 
     if [ $valid_ip4 ];then
         apache_set_listen_address "$listen_address"
+    elif [ $valid_ip6 ];then
+        # IPv6 Addresses must be wrapped inside square brackets
+        apache_set_listen_address "[$listen_address]"
     else
         echo "\"$listen_address\" is not a valid IP address" >&2
         return 0
@@ -41,6 +50,10 @@ handle_apache_listen_address_config()
     if ! restart_apache_if_running; then
 		return 6
 	fi
+
+    # Since snapctl only gives us new values, keep track of the current values
+	# so we know when they change.
+    apache_set_previous_listen_address "$listen_address"
 }
 
 handle_apache_port_config()
@@ -67,7 +80,6 @@ handle_apache_port_config()
 		return 2
 	fi
 
-    
 	apache_set_http_port "$http_port"
 	apache_set_https_port "$https_port"
 


### PR DESCRIPTION
Implementes/Fixes #331 
https://github.com/nextcloud/nextcloud-snap/issues/331

'Configuration of Listen address implemented through configuration hook, like "sudo snap set nextcloud listen-address=127.0.0.1".

Just added a commit with changes to the README.md, hope it can be of use :-)