### PR TITLE
apache: remove extra semicolon from hsts header

### DIFF
--- a/snap/plugins/x-php.py
+++ b/snap/plugins/x-php.py
@@ -99,7 +99,19 @@ class PhpPlugin(autotools.AutotoolsPlugin):
         if os.path.exists(self.extensions_directory):
             shutil.rmtree(self.extensions_directory)
 
+    def _replace_arch_triplet(self):
+        pattern = re.compile(r'ARCH_TRIPLET')
+
+        old_configflags = self.options.configflags
+        self.options.configflags = []
+        for flag in old_configflags:
+            self.options.configflags.append(
+                pattern.sub(self.project.arch_triplet, flag))
+
     def build(self):
+        # Replace ARCH_TRIPLET in options
+        self._replace_arch_triplet()
+
         super().build()
 
         if self.extensions:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -173,8 +173,13 @@ parts:
       - --with-mcrypt
       - --enable-exif
       - --enable-intl
+      - --enable-pcntl
       - --with-jpeg-dir=/usr/lib
       - --disable-rpath
+
+      # Enable ldap.
+      - --with-libdir=lib/ARCH_TRIPLET
+      - --with-ldap
     stage-packages:
       # These are only included here until the OS snap stabilizes
       - libxml2
@@ -186,6 +191,7 @@ parts:
       - libjpeg9-dev
       - libbz2-dev
       - libmcrypt-dev
+      - libldap2-dev
     prime:
      - -sbin/
      - -etc/

--- a/src/apache/conf/ssl.conf
+++ b/src/apache/conf/ssl.conf
@@ -161,6 +161,6 @@ SSLRandomSeed connect file:/dev/urandom 512
 
     # Enable HSTS only if requested
     <IfDefine EnableHSTS>
-        Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains;"
+        Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains"
     </IfDefine>
 </VirtualHost>


### PR DESCRIPTION
This is suggested by hstspreload.org

![hstspreload.org](https://user-images.githubusercontent.com/17193640/35219519-4616597a-ff73-11e7-90d7-23b7ac1f2330.PNG)