### PR TITLE
fix: Add xvfb to test dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ dependencies:
     $ cd tests/
     $ bundle install
 
+Additionally, if you do not have X configured, install the following for a
+'fake' X server.
+
+    $ sudo apt install xvfb
+
 Make sure the snap has a user called "admin" with password "admin" (used for
 login tests):
 


### PR DESCRIPTION
Tests could not be run as described in README.md under Hacking, as
a dependency, xvfb, was missing. Now added.

Closes nextcloud/nextcloud-snap#460