### PR TITLE
apache: remove 'includeSubDomains' from HSTS header

### DIFF
--- a/src/apache/conf/ssl.conf
+++ b/src/apache/conf/ssl.conf
@@ -161,6 +161,6 @@ SSLRandomSeed connect file:/dev/urandom 512
 
     # Enable HSTS only if requested
     <IfDefine EnableHSTS>
-        Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains"
+        Header always set Strict-Transport-Security "max-age=63072000"
     </IfDefine>
 </VirtualHost>


### PR DESCRIPTION
Fixes #435