### PR TITLE
[11] apache: update to 2.4.29

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -92,8 +92,8 @@ hooks:
 parts:
   apache:
     plugin: apache
-    source: http://ftp.wayne.edu/apache/httpd/httpd-2.4.28.tar.bz2
-    source-checksum: sha256/c1197a3a62a4ab5c584ab89b249af38cf28b4adee9c0106b62999fd29f920666
+    source: http://ftp.wayne.edu/apache/httpd/httpd-2.4.29.tar.bz2
+    source-checksum: sha256/777753a5a25568a2a27428b2214980564bc1c38c1abf9ccc7630b639991f7f00
 
     # The built-in Apache modules to enable
     modules:


### PR DESCRIPTION
This is a backport of #478 to v11, resolving #477 for v11.