### PR TITLE
Clean up trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ storage (or otherwise use a device in `/media` for data), you need to give the
 snap permission to access removable media by connecting that interface:
 
     $ sudo snap connect nextcloud:removable-media
-    
-    
+
+
 ### Configuration
 
 Beyond the typical Nextcloud configuration (either by using `nextcloud.occ` or
@@ -81,7 +81,7 @@ a proxy; you might notice it redirecting incorrectly. If this happens, override
 the automatic detection (including the port if necessary), e.g.:
 
     $ sudo nextcloud.occ config:set overwritehost --value="example.com:81"
-    
+
 
 #### PHP Memory limit configuration
 
@@ -92,7 +92,7 @@ log, you may need to set this to a higher value.
 If you'd like to set the memory limit to a higher value (say, 512M), run:
 
     $ sudo snap set nextcloud php.memory-limit=512M
-    
+
 To set it to be unlimited (not recommended), use -1:
 
     $ sudo snap set nextcloud php.memory-limit=-1

--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -14,7 +14,7 @@ ServerRoot "${SNAP}"
 # ports, instead of the default. See also the <VirtualHost>
 # directive.
 #
-# Change this to Listen on specific IP addresses as shown below to 
+# Change this to Listen on specific IP addresses as shown below to
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
@@ -74,7 +74,7 @@ LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
 
 #
 # Deny access to the entirety of your server's filesystem. You must
-# explicitly permit access to web content directories in other 
+# explicitly permit access to web content directories in other
 # <Directory> blocks below.
 #
 <Directory />
@@ -145,8 +145,8 @@ Alias "/.well-known/acme-challenge" "${SNAP_DATA}/certs/certbot/.well-known/acme
 </Directory>
 
 #
-# The following lines prevent .htaccess and .htpasswd files from being 
-# viewed by Web clients. 
+# The following lines prevent .htaccess and .htpasswd files from being
+# viewed by Web clients.
 #
 <Files ".ht*">
     Require all denied

--- a/src/apache/conf/ssl.conf
+++ b/src/apache/conf/ssl.conf
@@ -3,7 +3,7 @@
 # ports, instead of the default. See also the <VirtualHost>
 # directive.
 #
-# Change this to Listen on specific IP addresses as shown below to 
+# Change this to Listen on specific IP addresses as shown below to
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
@@ -50,7 +50,7 @@ SSLProxyProtocol all -SSLv3
 SSLPassPhraseDialog  builtin
 
 #   Inter-Process Session Cache:
-#   Configure the SSL Session Cache: First the mechanism 
+#   Configure the SSL Session Cache: First the mechanism
 #   to use and second the expiring timeout (in seconds).
 SSLSessionCache        "shmcb:${SNAP_DATA}/apache/ssl_scache(512000)"
 SSLSessionCacheTimeout  300
@@ -123,7 +123,7 @@ SSLRandomSeed connect file:/dev/urandom 512
     #     and no other module can change it.
     #   o OptRenegotiate:
     #     This enables optimized SSL connection renegotiation handling when SSL
-    #     directives are used in per-directory context. 
+    #     directives are used in per-directory context.
     <FilesMatch "\.(cgi|shtml|phtml|php)$">
         SSLOptions +StdEnvVars
     </FilesMatch>
@@ -148,7 +148,7 @@ SSLRandomSeed connect file:/dev/urandom 512
     #     alert of the client. This is 100% SSL/TLS standard compliant, but in
     #     practice often causes hanging connections with brain-dead browsers. Use
     #     this only for browsers where you know that their SSL implementation
-    #     works correctly. 
+    #     works correctly.
     #   Notice: Most problems of broken clients are also related to the HTTP
     #   keep-alive facility, so you usually additionally want to disable
     #   keep-alive for those clients, too. Use variable "nokeepalive" for this.

--- a/src/mysql/support-files/mysql.server
+++ b/src/mysql/support-files/mysql.server
@@ -24,7 +24,7 @@
 # Short-Description: start and stop MySQL
 # Description: MySQL is a very fast and reliable SQL database engine.
 ### END INIT INFO
- 
+
 # If you install MySQL on some other places than /, then you
 # have to do one of the following things for this script to work:
 #
@@ -49,8 +49,8 @@ basedir=$SNAP
 datadir=$SNAP_DATA/mysql
 
 # Default value, in seconds, afterwhich the script should timeout waiting
-# for server start. 
-# Value here is overriden by value in my.cnf. 
+# for server start.
+# Value here is overriden by value in my.cnf.
 # 0 means don't wait at all
 # Negative numbers mean to wait indefinitely
 service_startup_timeout=900
@@ -173,7 +173,7 @@ wait_for_pid () {
       if kill -0 "$pid" 2>/dev/null; then
         :  # the server still runs
       else
-        # The server may have exited between the last pid-file check and now.  
+        # The server may have exited between the last pid-file check and now.
         if test -n "$avoid_race_condition"; then
           avoid_race_condition=""
           continue  # Check again.
@@ -353,9 +353,9 @@ case "$mode" in
     ;;
   'status')
     # First, check to see if pid file exists
-    if test -s "$mysqld_pid_file_path" ; then 
+    if test -s "$mysqld_pid_file_path" ; then
       read mysqld_pid < "$mysqld_pid_file_path"
-      if kill -0 $mysqld_pid 2>/dev/null ; then 
+      if kill -0 $mysqld_pid 2>/dev/null ; then
         log_success_msg "MySQL running ($mysqld_pid)"
         exit 0
       else
@@ -371,11 +371,11 @@ case "$mode" in
       if test $pid_count -gt 1 ; then
         log_failure_msg "Multiple MySQL running but PID file could not be found ($mysqld_pid)"
         exit 5
-      elif test -z $mysqld_pid ; then 
-        if test -f "$lock_file_path" ; then 
+      elif test -z $mysqld_pid ; then
+        if test -f "$lock_file_path" ; then
           log_failure_msg "MySQL is not running, but lock file ($lock_file_path) exists"
           exit 2
-        fi 
+        fi
         log_failure_msg "MySQL is not running"
         exit 3
       else

--- a/tests/Rakefile
+++ b/tests/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rspec/core/rake_task'
- 
+
 RSpec::Core::RakeTask.new(:test) do |t|
 	t.pattern = Dir.glob('spec/**/*_spec.rb')
 	t.rspec_opts = "--format documentation"


### PR DESCRIPTION
Throw away trailing whitespace that git complained about.
Files containing trailing whitespace were identified using
```
  grep -r '\s$' .
```
in the root of the repository.

Closes nextcloud/nextcloud-snap#487