### PR TITLE
apache: stop waiting for services when stopping

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,7 +12,7 @@ apps:
   # Apache daemon
   apache:
     command: run-httpd -k start -DFOREGROUND
-    stop-command: run-httpd -k stop
+    stop-command: httpd-wrapper -k stop
     daemon: simple
     restart-condition: always
     plugs: [network, network-bind]


### PR DESCRIPTION
This PR fixes #526 by stopping using `httpd-wrapper` instead of `run-httpd`, which waits for services that will never come when stopping.