### PR TITLE
[11] apache: stop waiting for services when stopping

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,7 +12,7 @@ apps:
   # Apache daemon
   apache:
     command: run-httpd -k start -DFOREGROUND
-    stop-command: run-httpd -k stop
+    stop-command: httpd-wrapper -k stop
     daemon: simple
     restart-condition: always
     plugs: [network, network-bind]


### PR DESCRIPTION
This PR is a backport of #527, fixing #526 for v11.