### PR TITLE
php: use configured memory limit for PHP CLI utilities

### DIFF
--- a/src/nextcloud/bin/nextcloud-cron
+++ b/src/nextcloud/bin/nextcloud-cron
@@ -10,6 +10,6 @@ done
 echo "done"
 
 while true; do
-	php -c $SNAP/config/php $SNAP/htdocs/cron.php
+	run-php $SNAP/htdocs/cron.php
 	sleep 15m
 done

--- a/src/nextcloud/bin/occ
+++ b/src/nextcloud/bin/occ
@@ -14,4 +14,4 @@ fi
 wait_for_php
 wait_for_nextcloud_to_be_configured
 
-php -c $SNAP/config/php $SNAP/htdocs/occ "$@"
+run-php $SNAP/htdocs/occ "$@"

--- a/src/php/bin/run-php
+++ b/src/php/bin/run-php
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+. $SNAP/utilities/php-utilities
+
+export PHP_MEMORY_LIMIT="$(php_memory_limit)"
+
+php -c $SNAP/config/php "$@"

--- a/src/php/config/php.ini
+++ b/src/php/config/php.ini
@@ -386,7 +386,9 @@ max_input_time = 3600
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit
-memory_limit = 128M
+;memory_limit = 128M
+; Allow for a dynamic PHP memory limit
+memory_limit = ${PHP_MEMORY_LIMIT}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;


### PR DESCRIPTION
PHP-FPM currently supports configuring a memory limit using `snap set`. However, CLI utilities (specifically `occ` and the cron job) use a different configuration file, and don't support changing the memory limit.

This PR fixes #550 by adding support for the same memory limit configuration to CLI utilities.