### PR TITLE
mysql: don't consider mysql available until after restart

### DIFF
--- a/src/mysql/bin/start_mysql
+++ b/src/mysql/bin/start_mysql
@@ -12,6 +12,8 @@ if mysqld --initialize-insecure --basedir="$SNAP" --datadir="$SNAP_DATA/mysql" -
 	new_install=true
 fi
 
+set_mysql_setup_running
+
 # Start mysql
 "$SNAP/support-files/mysql.server" start
 
@@ -65,7 +67,7 @@ else
 fi
 
 # Wait here until mysql is running
-wait_for_mysql
+wait_for_mysql -f
 
 # Check and upgrade mysql tables if necessary. This will return 0 if the upgrade
 # succeeded, in which case we need to restart mysql.
@@ -75,7 +77,7 @@ if mysql_upgrade --defaults-file="$root_option_file"; then
 	"$SNAP/support-files/mysql.server" restart
 
 	# Wait for server to come back after upgrade
-	wait_for_mysql
+	wait_for_mysql -f
 fi
 
 # If this was a new installation, wait until the server is all up and running
@@ -84,6 +86,8 @@ fi
 if [ $new_install = true ]; then
 	mysql_set_nextcloud_password "$nextcloud_password"
 fi
+
+set_mysql_setup_not_running
 
 # Wait here until mysql exits (turn a forking service into simple). This is
 # only needed for Ubuntu Core 15.04, as 16.04 supports forking services.

--- a/src/mysql/utilities/mysql-utilities
+++ b/src/mysql/utilities/mysql-utilities
@@ -3,6 +3,7 @@
 export MYSQL_PIDFILE="/tmp/pids/mysql.pid"
 export MYSQL_SOCKET="/tmp/sockets/mysql.sock"
 export NEXTCLOUD_PASSWORD_FILE="$SNAP_DATA/mysql/nextcloud_password"
+MYSQL_SETUP_LOCKFILE="/tmp/locks/mysql-setup"
 
 mkdir -p "$(dirname "$MYSQL_PIDFILE")"
 mkdir -p "$(dirname "$MYSQL_SOCKET")"
@@ -11,18 +12,37 @@ chmod 750 "$(dirname "$MYSQL_SOCKET")"
 
 mysql_is_running()
 {
-	[ -f "$MYSQL_PIDFILE" ] && [ -S "$MYSQL_SOCKET" ]
+	# Arguments:
+	#  -f: Force the check, i.e. ignore if it's currently in setup
+	[ -f "$MYSQL_PIDFILE" ] && [ -S "$MYSQL_SOCKET" ] && (! mysql_setup_running || [ "$1" = "-f" ])
 }
 
 wait_for_mysql()
 {
-	if ! mysql_is_running; then
+	# Arguments:
+	#  -f: Force the check, i.e. ignore if it's currently in setup
+	if ! mysql_is_running "$@"; then
 		printf "Waiting for MySQL... "
-		while ! mysql_is_running; do
+		while ! mysql_is_running "$@"; do
 			sleep 1
 		done
 		printf "done\n"
 	fi
+}
+
+mysql_setup_running()
+{
+	[ -f "$MYSQL_SETUP_LOCKFILE" ]
+}
+
+set_mysql_setup_running()
+{
+	touch "$MYSQL_SETUP_LOCKFILE"
+}
+
+set_mysql_setup_not_running()
+{
+	rm -f "$MYSQL_SETUP_LOCKFILE"
 }
 
 mysql_pid()

--- a/src/nextcloud/bin/manual-install
+++ b/src/nextcloud/bin/manual-install
@@ -49,6 +49,8 @@ password=$2
 
 # We can't do anything until PHP and MySQL are up and running
 wait_for_php
+
+# shellcheck disable=SC2119
 wait_for_mysql
 
 # Now we can use 'occ maintenance:install'

--- a/src/php/bin/start-php-fpm
+++ b/src/php/bin/start-php-fpm
@@ -19,6 +19,7 @@ chmod 750 "${SNAP_DATA}/php"
 wait_for_configure_hook
 
 # We need to make sure mysql is running so we can run the migration process
+# shellcheck disable=SC2119
 wait_for_mysql
 
 # Wait until we have an nextcloud mysql password


### PR DESCRIPTION
The process of actually firing MySQL up includes upgrading its schema, after which it's restarted. If other daemons fire up at the right time, they could already be relying on MySQL's presence when it restarts out from under them.

This PR fixes #607 by ensuring that other daemons don't consider MySQL ready until after it has
completed this logic.