### PR TITLE
apache: add TLS settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ the automatic detection (including the port if necessary), e.g.:
     $ sudo nextcloud.occ config:system:set overwritehost --value="example.com:81"
 
 
+#### TLS configuration
+
+By default apache accepts the Tlsv1, Tlsv1.1 and Tlsv1.2 versions and a cipher list that is compatible with most browsers.
+
+To disable Tlsv1 and Tlsv1.1 and use a newer cipher list, run:
+
+    $ sudo snap set nextcloud apache.oldtls=false
+
+To enable older TLS protocols and ciphers again (increased compability), run:
+
+    $ sudo snap set nextcloud apache.oldtls=true
+
+Note that, if you disable older TLS versions and ciphers, certain (outdated) browsers won't be able to visit your Nextcloud instance anymore.
+
+
 #### PHP Memory limit configuration
 
 By default, PHP will use 128M as the memory limit. If you notice images not

--- a/src/apache/bin/httpd-wrapper
+++ b/src/apache/bin/httpd-wrapper
@@ -23,6 +23,11 @@ else
 	echo "No certificates are active: using HTTP only"
 fi
 
+if [ "$(apache_old_tls)" = "false" ] ; then
+	params="$params -DDisableOldTls"
+	echo "Old TLS protocols and ciphers are disabled"
+fi
+
 HTTP_PORT="$(apache_http_port)"
 HTTPS_PORT="$(apache_https_port)"
 export HTTP_PORT

--- a/src/apache/conf/ssl.conf
+++ b/src/apache/conf/ssl.conf
@@ -40,8 +40,22 @@ LoadModule ssl_module modules/mod_ssl.so
 #   Disable SSLv3 by default (cf. RFC 7525 3.1.1).  TLSv1 (1.0) should be
 #   disabled as quickly as practical.  By the end of 2016, only the TLSv1.2
 #   protocol or later should remain in use.
-SSLProtocol all -SSLv3
-SSLProxyProtocol all -SSLv3
+
+SSLHonorCipherOrder On
+
+<IfDefine DisableOldTls>
+  SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
+  SSLProxyProtocol all -SSLv3 -TLSv1 -TLSv1.1
+  SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
+</IfDefine>
+
+<IfDefine !DisableOldTls>
+  SSLProtocol all -SSLv3
+  SSLProxyProtocol all -SSLv3
+  SSLCipherSuite ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS;
+</IfDefine>
+
+
 
 #   Pass Phrase Dialog:
 #   Configure the pass phrase gathering process.
@@ -90,9 +104,6 @@ SSLRandomSeed connect file:/dev/urandom 512
     RewriteRule .* - [R=405,L]
 
     SSLEngine on
-    SSLHonorCipherOrder On
-    SSLCipherSuite ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS;
-
     SSLCertificateFile      ${SNAP_DATA}/certs/live/cert.pem
     SSLCertificateKeyFile   ${SNAP_DATA}/certs/live/privkey.pem
     SSLCertificateChainFile ${SNAP_DATA}/certs/live/chain.pem

--- a/src/apache/utilities/apache-utilities
+++ b/src/apache/utilities/apache-utilities
@@ -105,3 +105,31 @@ apache_set_previous_https_port()
 {
 	snapctl set private.ports.https="$1"
 }
+
+
+apache_old_tls()
+{
+	old_tls="$(snapctl get apache.oldtls)"
+	if [ -z "$old_tls" ]; then
+		old_tls="true"
+		apache_set_old_tls $old_tls
+		apache_set_previous_old_tls $old_tls
+	fi
+
+	echo "$old_tls"
+}
+
+apache_set_old_tls()
+{
+	snapctl set apache.oldtls="$1"
+}
+
+apache_get_previous_old_tls()
+{
+	snapctl get private.apache.oldtls
+}
+
+apache_set_previous_old_tls()
+{
+	snapctl set private.apache.oldtls="$1"
+}

--- a/src/hooks/bin/configure
+++ b/src/hooks/bin/configure
@@ -15,6 +15,9 @@
 # - nextcloud.cron-interval (string)
 #   Interval of the internal Nextcloud cronjob
 #
+# - apache.oldtls (string)
+#   Specify if older tls versions and ciphers should be allowed
+#
 
 # shellcheck source=src/apache/utilities/apache-utilities
 . "$SNAP/utilities/apache-utilities"
@@ -112,9 +115,38 @@ handle_cronjob_interval()
 	snapctl restart nextcloud.nextcloud-cron
 }
 
+
+handle_tls_settings()
+{
+	old_tls="$(apache_old_tls)"
+	previous_old_tls="$(apache_get_previous_old_tls)"
+
+	# If no changes were requested, then there's nothing to do here.
+	if [ "$old_tls" = "$previous_old_tls" ]; then
+		return 0
+	fi
+
+	# Validate input
+	if [ "$old_tls" = "true" ] || [ "$old_tls" = "false" ] ; then
+		apache_set_old_tls "$old_tls"
+	else
+		echo "$old_tls is not a valid option"
+		return 1
+	fi
+
+
+	# restart apache
+	if ! restart_apache_if_running; then
+		return 1
+	fi
+
+	# set previous value
+	apache_set_previous_old_tls "$old_tls"
+}
+
 # Signal to services that the configure hook is running. Useful to ensure
 # services don't restart until the configuration transaction has completed.
 set_configure_hook_running
 trap 'set_configure_hook_not_running' EXIT
 
-handle_apache_port_config && handle_php_memory_limit && handle_cronjob_interval
+handle_apache_port_config && handle_php_memory_limit && handle_cronjob_interval && handle_tls_settings


### PR DESCRIPTION
Fixes #616 

I think the simplest (and also most user friendly) way to implement TLS settings is to specify two "modes" (old and modern). 
In this PR this is done using the `apache.oldtls` setting. 

Feel free to suggest changes or improvements to this.
