### PR TITLE
Add FTP support in PHP

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -181,6 +181,7 @@ parts:
       - --with-jpeg-dir=/usr/lib
       - --with-freetype-dir=/usr/lib
       - --disable-rpath
+      - --enable-ftp
 
       # Enable ldap.
       - --with-libdir=lib/ARCH_TRIPLET


### PR DESCRIPTION
Compile PHP with FTP support to allow mounting FTP locations as external storage.

When merged, this should fix #503