### PR TITLE
occ: don't require PHP restart for maintenance mode

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -220,7 +220,7 @@ parts:
     source: src/php/
     organize:
       config/*: config/php/
-    stage-packages: [mawk]
+    stage-packages: [mawk, libfcgi0ldbl]
 
   # Copy over our Nextcloud configuration files
   nextcloud-customizations:

--- a/src/nextcloud/bin/occ
+++ b/src/nextcloud/bin/occ
@@ -19,3 +19,7 @@ wait_for_php
 wait_for_nextcloud_to_be_configured
 
 run-php "$SNAP/htdocs/occ" "$@"
+
+# occ may have modified the config. Invalidate its cache just in case, otherwise
+# PHP won't see the changes.
+php_invalidate_opcache "$NEXTCLOUD_CONFIG_DIR/config.php"

--- a/src/php/utilities/php-utilities
+++ b/src/php/utilities/php-utilities
@@ -80,3 +80,18 @@ php_set_previous_memory_limit()
 {
 	snapctl set private.php.memory-limit="$1"
 }
+
+php_invalidate_opcache()
+{
+	tmpfile="$(mktemp --tmpdir tmp_XXXXXXXXXX.php)"
+	echo "<?php opcache_invalidate('$1'); ?>" > "$tmpfile"
+
+	export SCRIPT_FILENAME="$tmpfile"
+	export REQUEST_METHOD="GET"
+	if ! output="$(cgi-fcgi -bind -connect "$PHP_FPM_SOCKET")"; then
+		echo "Unable to invalidate opcache: $output" >&2
+	fi
+
+	# Dash doesn't support trap RETURN
+	rm -f "$tmpfile"
+}

--- a/tests/spec/maintenance_mode_spec.rb
+++ b/tests/spec/maintenance_mode_spec.rb
@@ -1,0 +1,24 @@
+feature "Maintenance mode" do
+    # Regression test for #486.
+    scenario "enable/disable" do
+        # First, verify that maintenance mode is not active
+        visit "/"
+        expect(page).not_to have_content('maintenance mode')
+
+        # Enable maintenance mode
+		`sudo nextcloud.occ maintenance:mode --on`
+        expect($?.to_i).to eq 0
+
+        # Now verify that maintenance mode is active
+        visit "/"
+        expect(page).to have_content('maintenance mode')
+
+        # Now disable maintenance mode
+        `sudo nextcloud.occ maintenance:mode --off`
+        expect($?.to_i).to eq 0
+
+        # Finally, verify that maintenance mode is not active again
+        visit "/"
+        expect(page).not_to have_content('maintenance mode')
+	end
+end


### PR DESCRIPTION
The `nextcloud.occ` command is often used to alter the Nextcloud config, which is a .php file. As such, it's subject to the same opcache settings as the rest of PHP, which doesn't even look at the tree to see if files have changed (`opcache.validate_timestamps=0`). As a result, any change made to `config.php` without restarting PHP goes unnoticed, which includes changes like enabling maintenance mode.

This PR fixes #486 by assuming the config has changed after using `nextcloud.occ`, and invalidating the opcache for the config so that it's reloaded.