### PR TITLE
Add the ability to import/export install

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ apps:
 
   # MySQL client
   mysql-client:
-    command: mysql --defaults-file=$SNAP_DATA/mysql/root.ini
+    command: run-mysql
     plugs: [network, network-bind]
 
   mysqldump:
@@ -83,6 +83,14 @@ apps:
   # Command for manually installing instead of visiting site to create admin.
   manual-install:
     command: manual-install
+    plugs: [network, network-bind, removable-media]
+
+  import:
+    command: import-data
+    plugs: [network, network-bind, removable-media]
+
+  export:
+    command: export-data
     plugs: [network, network-bind, removable-media]
 
 hooks:
@@ -347,6 +355,11 @@ parts:
     source: src/https/
     stage-packages: [openssl]
     stage: [-etc/ssl, -patches]
+
+  import-export:
+    plugin: dump
+    source: src/import-export
+    stage-packages: [rsync]
 
   hooks:
     plugin: dump

--- a/src/import-export/bin/export-data
+++ b/src/import-export/bin/export-data
@@ -1,0 +1,181 @@
+#!/bin/sh
+
+if [ "$(id -u)" -ne 0 ]; then
+	echo "This utility needs to run as root"
+	exit 1
+fi
+
+# shellcheck source=src/nextcloud/utilities/nextcloud-utilities
+. "$SNAP/utilities/nextcloud-utilities"
+# shellcheck source=src/mysql/utilities/mysql-utilities
+. "$SNAP/utilities/mysql-utilities"
+
+# shellcheck disable=SC2119
+wait_for_mysql
+
+COMMAND="nextcloud.export"
+BACKUP_DIRECTORY="${SNAP_COMMON}/backups"
+FORMAT="1"
+
+print_usage()
+{
+	echo "Usage:"
+	echo "    $COMMAND [OPTIONS]"
+	echo "    Export data suitable for migrating servers. By default this"
+	echo "    includes the Nextcloud database, configuration, and data"
+	echo "    (equivalent to running $COMMAND -abcd)."
+	echo ""
+	echo "Available options:"
+	echo "    -h: Display this help message"
+	echo "    -a: Include the (non-default) apps"
+	echo "    -b: Include the database"
+	echo "    -c: Include the config"
+	echo "    -d: Include the data (can be quite large)"
+}
+
+export_apps()
+{
+	backup="$1"
+	echo "Exporting apps..."
+	if ! rsync -ah --info=progress2 "$SNAP_DATA/nextcloud/extra-apps/" "${backup}/apps"; then
+		echo "Unable to export apps"
+		exit 1
+	fi
+}
+
+export_database()
+{
+	backup="$1"
+	echo "Exporting database..."
+	if ! mysqldump --defaults-file="$SNAP_DATA/mysql/root.ini" \
+	             --lock-tables nextcloud > "${backup}/database.sql"; then
+		echo "Unable to export database"
+		exit 1
+	fi
+}
+
+export_config()
+{
+	backup="$1"
+	config_backup="${backup}/config.php"
+
+	# Mask out the config password. We don't need it when restoring.
+	echo "Exporting config..."
+	if ! sed "s/\(dbpassword.*=>\s*\).*,/\1'DBPASSWORD',/" \
+	       "${SNAP_DATA}/nextcloud/config/config.php" > "$config_backup"; then
+		echo "Unable to export config"
+		exit 1
+	fi
+}
+
+export_data()
+{
+	backup="$1"
+	echo "Exporting data..."
+	if ! rsync -ah --info=progress2 "${NEXTCLOUD_DATA_DIR%/}/" "${backup}/data"; then
+		echo "Unable to export data"
+		exit 1
+	fi
+}
+
+run_command()
+{
+	printf "%s... " "$2"
+	if output="$(eval "$1" 2>&1)"; then
+		echo "done"
+		return 0;
+	else
+		echo "error"
+		echo "$output"
+		return 1;
+	fi
+}
+
+enable_maintenance_mode()
+{
+	run_command "occ maintenance:mode --on" "Enabling maintenance mode"
+}
+
+disable_maintenance_mode()
+{
+	run_command "occ maintenance:mode --off" "Disabling maintenance mode"
+}
+
+do_export_apps=false
+do_export_database=false
+do_export_config=false
+do_export_data=false
+
+# If no parameters are specified, default to exporting everything
+if [ $# -eq 0 ]; then
+	do_export_apps=true
+	do_export_database=true
+	do_export_config=true
+	do_export_data=true
+fi
+
+while getopts ":abcdh" opt; do
+	case $opt in
+		a)
+			do_export_apps=true
+			;;
+		b)
+			do_export_database=true
+			;;
+		c)
+			do_export_config=true
+			;;
+		d)
+			do_export_data=true
+			;;
+		h)
+			print_usage
+			exit 0
+			;;
+		\?)
+			echo "Invalid option: -$OPTARG" >&2
+			exit 1
+			;;
+	esac
+done
+
+# Clear options
+shift "$((OPTIND-1))"
+
+echo "WARNING: This functionality is still experimental and under" >&2
+echo "development, use at your own risk. Note that the CLI interface is" >&2
+echo "unstable, so beware if using from within scripts." >&2
+echo "" >&2
+
+backup="${BACKUP_DIRECTORY}/$(date +%Y%m%d-%H%M%S)"
+
+mkdir -p "$backup"
+chmod 750 "$backup"
+
+echo "$FORMAT" > "${backup}/format"
+
+# Enable maintenance mode so data can't change out from under us
+if ! enable_maintenance_mode; then
+	echo "Unable to enter maintenance mode"
+	exit 1
+fi
+trap 'disable_maintenance_mode' EXIT
+
+if [ "$do_export_apps" = true ]; then
+	export_apps "$backup"
+fi
+
+if [ "$do_export_database" = true ]; then
+	export_database "$backup"
+fi
+
+if [ "$do_export_config" = true ]; then
+	export_config "$backup"
+fi
+
+if [ "$do_export_data" = true ]; then
+	export_data "$backup"
+fi
+
+echo ""
+echo "Successfully exported $backup"

--- a/src/import-export/bin/import-data
+++ b/src/import-export/bin/import-data
@@ -1,0 +1,191 @@
+#!/bin/sh
+
+if [ "$(id -u)" -ne 0 ]; then
+	echo "This utility needs to run as root"
+	exit 1
+fi
+
+# shellcheck source=src/nextcloud/utilities/nextcloud-utilities
+. "$SNAP/utilities/nextcloud-utilities"
+# shellcheck source=src/mysql/utilities/mysql-utilities
+. "$SNAP/utilities/mysql-utilities"
+
+# shellcheck disable=SC2119
+wait_for_mysql
+
+COMMAND="nextcloud.import"
+
+print_usage()
+{
+	echo "Usage:"
+	echo "    $COMMAND [OPTIONS] <backup dir>"
+	echo "    Import data exported from another Nextcloud snap instance."
+	echo "    By default this imports the database, config, and data"
+	echo "    (equivalent to running $COMMAND -abcd)."
+	echo ""
+	echo "Available options:"
+	echo "    -h: Display this help message"
+	echo "    -a: Import the (non-default) apps"
+	echo "    -b: Import the database"
+	echo "    -c: Import the config"
+	echo "    -d: Import the data"
+}
+
+import_apps()
+{
+	backup_dir="${1%/}"
+	apps_backup="${backup_dir}/apps"
+	run_command "rm -rf \"$SNAP_DATA/nextcloud/extra-apps\"" "Clearing existing non-default apps"
+	echo "Importing apps..."
+	if ! rsync -ah --info=progress2 "$apps_backup/" "$SNAP_DATA/nextcloud/extra-apps"; then
+		echo "Unable to import apps"
+		exit 1
+	fi
+}
+
+import_database()
+{
+	backup_dir="$1"
+	database_backup="${backup_dir}/database.sql"
+
+	# First, drop the database (if any)
+	run_command "run-mysql -e \"DROP DATABASE nextcloud\"" \
+	            "Dropping existing database"
+	run_command "run-mysql -e \"CREATE DATABASE nextcloud\"" \
+	            "Creating new database"
+	run_command "run-mysql -e \"GRANT ALL PRIVILEGES ON nextcloud.* TO 'nextcloud'@'localhost'\"" \
+	            "Granting database privileges to existing user"
+
+	# Now restore the database
+	echo "Importing database..."
+	if ! run-mysql nextcloud < "$database_backup"; then
+		echo "Unable to import database"
+		exit 1
+	fi
+}
+
+import_config()
+{
+	backup_dir="$1"
+	config_backup="${backup_dir}/config.php"
+	database_password="$(mysql_get_nextcloud_password)"
+
+	# Import the config, but set our new database password
+	echo "Importing config..."
+	if ! sed "s/DBPASSWORD/$database_password/" \
+	         "$config_backup" > "${SNAP_DATA}/nextcloud/config/config.php"; then
+		echo "Unable to import config"
+		exit 1
+	fi
+}
+
+import_data()
+{
+	backup_dir="${1%/}"
+	data_backup="${backup_dir}/data"
+	run_command "rm -rf \"$NEXTCLOUD_DATA_DIR\"" "Clearing existing data"
+	echo "Importing data..."
+	if ! rsync -ah --info=progress2 "$data_backup/" "$NEXTCLOUD_DATA_DIR"; then
+		echo "Unable to import data"
+		exit 1
+	fi
+}
+
+run_command()
+{
+	printf "%s... " "$2"
+	if output="$(eval "$1" 2>&1)"; then
+		echo "done"
+		return 0;
+	else
+		echo "error"
+		echo "$output"
+		return 1;
+	fi
+}
+
+enable_maintenance_mode()
+{
+	run_command "occ maintenance:mode --on" "Enabling maintenance mode"
+}
+
+disable_maintenance_mode()
+{
+	run_command "occ maintenance:mode --off" "Disabling maintenance mode"
+}
+
+do_import_apps=false
+do_import_database=false
+do_import_config=false
+do_import_data=false
+
+# If no parameters are specified, default to importing everything
+if [ $# -eq 1 ]; then
+	do_import_apps=true
+	do_import_database=true
+	do_import_config=true
+	do_import_data=true
+fi
+
+while getopts ":abcdh" opt; do
+	case $opt in
+		a)
+			do_import_apps=true
+			;;
+		b)
+			do_import_database=true
+			;;
+		c)
+			do_import_config=true
+			;;
+		d)
+			do_import_data=true
+			;;
+		h)
+			print_usage
+			exit 0
+			;;
+		\?)
+			echo "Invalid option: -$OPTARG" >&2
+			exit 1
+			;;
+	esac
+done
+
+# Clear options
+shift "$((OPTIND-1))"
+
+echo "WARNING: This functionality is still experimental and under" >&2
+echo "development, use at your own risk. Note that the CLI interface is" >&2
+echo "unstable, so beware if using from within scripts." >&2
+echo "" >&2
+
+# Enable maintenance mode so data can't change out from under us
+if ! enable_maintenance_mode; then
+	echo "Unable to enter maintenance mode"
+	exit 1
+fi
+trap 'disable_maintenance_mode' EXIT
+
+backup_dir="$1"
+if [ -z "$backup_dir" ]; then
+	echo "Missing parameter <backup dir>"
+	print_usage
+	exit 1
+fi
+
+if [ "$do_import_apps" = true ]; then
+	import_apps "$backup_dir"
+fi
+
+if [ "$do_import_database" = true ]; then
+	import_database "$backup_dir"
+fi
+
+if [ "$do_import_config" = true ]; then
+	import_config "$backup_dir"
+fi
+
+if [ "$do_import_data" = true ]; then
+	import_data "$backup_dir"
+fi

--- a/src/mysql/bin/run-mysql
+++ b/src/mysql/bin/run-mysql
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+mysql --defaults-file="$SNAP_DATA/mysql/root.ini" "$@"

--- a/tests/spec/import_export_spec.rb
+++ b/tests/spec/import_export_spec.rb
@@ -1,0 +1,42 @@
+feature "Import and export data" do
+	scenario "export then import" do
+		`sudo nextcloud.export`
+		expect($?.to_i).to eq 0
+
+		backups = Dir.glob("/var/snap/nextcloud/common/backups/*")
+		expect(backups.length).to eq 1
+		backup = backups[0]
+
+		# Move backup out of the snap's dirs
+		moved_backup = File.join(Dir.tmpdir, File.basename(backup))
+		`sudo mv "#{backup}" "#{moved_backup}"`
+
+		snap_paths = Dir.glob("/var/lib/snapd/snaps/nextcloud_*.snap")
+		expect(snap_paths.length).to eq 1
+		snap_path = snap_paths[0]
+
+		# Create a backup of the snap that's currently installed
+		moved_snap_path = File.join(Dir.tmpdir, File.basename(snap_path))
+		`sudo cp "#{snap_path}" "#{moved_snap_path}"`
+
+		# Now completely uninstall/reinstall the snap
+		`sudo snap remove nextcloud`
+		`sudo snap install "#{moved_snap_path}" --dangerous`
+
+		# Now restore the backup, and verify we can still login like normal
+		`sudo mkdir -p "$(dirname "#{backup}")"`
+		`sudo mv "#{moved_backup}" "#{backup}"`
+		`sudo nextcloud.import "#{backup}"`
+		assert_loginable
+	end
+
+	protected
+
+	def assert_loginable
+		visit "/"
+		fill_in "User", with: "admin"
+		fill_in "Password", with: "admin"
+		click_button "Log in"
+		expect(page).to have_content "Documents"
+	end
+end

--- a/tests/spec/spec_helper.rb
+++ b/tests/spec/spec_helper.rb
@@ -162,6 +162,9 @@ RSpec.configure do |config|
 		# Also make sure HTTPS is disabled
 		disable_https
 
+		# Make sure any and all backups are removed
+		`sudo rm -rf /var/snap/nextcloud/common/backups`
+
 		# Make sure we're usin the normal, HTTP host again
 		Capybara.app_host = 'http://localhost'
 	end


### PR DESCRIPTION
This PR resolves #185 by adding two new commands to the snap: `nextcloud.export` and `nextcloud.import`. They're pretty bare-bones right now, but they allow one to migrate between snap installs pretty easily by exporting the apps, database, config, and raw data. Note that this does not cover transferring other settings, like HTTPS certificates.

See `nextcloud.export -h` and `nextcloud.import -h` for more information. Please test this PR using the `beta/pr-688` channel:

    $ sudo snap install nextcloud --channel=beta/pr-688

Or, if you already have it installed:

    $ sudo snap refresh nextcloud --channel=beta/pr-688