### PR TITLE
snapcraft.yaml: use git version instead of hard-coding

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: nextcloud
-version: 13.0.7snap1
+version: git
 summary: Nextcloud Server - A safe home for all your data
 description: |
  Access, share and protect your files, calendars, contacts, communication and


### PR DESCRIPTION
This PR resolves #768, making the version more useful for non-stable snaps.