### PR TITLE
snapcraft.yaml: Large file support in 32bit.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -195,6 +195,9 @@ parts:
       # Enable ldap.
       - --with-libdir=lib/ARCH_TRIPLET
       - --with-ldap
+
+      # Enable LFS(Large File Support) for 32bit architecture(e.g: i386 or i686, ARMv7).
+      - CFLAGS=-D_LARGEFILE_SOURCE=1 -D_FILE_OFFSET_BITS=64
     stage-packages:
       # These are only included here until the OS snap stabilizes
       - libxml2


### PR DESCRIPTION
This patch helps nextcloud-snap open or process files larger than 2 GB in 32-bit.

nextcloud-snap will cause a "fopen: Value too large for defined data type" error when reading a file larger than 2G on 32-bit. This problem occurs not only on the web, but also on the webdav client (e.g. desktop client, mobile webdav client).

This error is because PHP does not natively support the large file support (LFS) option, which allows to process files larger than 2G in 32-bit(e.g. raspberry-pi, odroid-xu4, x86). I have checked this patch with Odroid-XU4(armv7l).

- armhf snap: https://launchpad.net/~hwiorn/+snap/nextcloud-for-32bit/+build/381922/+files/nextcloud_13.0.7snap1_armhf.snap
- arm64 snap: https://launchpad.net/~hwiorn/+snap/nextcloud-for-32bit/+build/381921/+files/nextcloud_13.0.7snap1_arm64.snap
- i386 snap: https://launchpad.net/~hwiorn/+snap/nextcloud-for-32bit/+build/381923/+files/nextcloud_13.0.7snap1_i386.snap
- amd64 snap: https://launchpad.net/~hwiorn/+snap/nextcloud-for-32bit/+build/381914/+files/nextcloud_13.0.7snap1_amd64.snap

This option appears to have no effect on 64-bit. However, testing will be necessary. It might be better to be able to dynamically configure snapcraft so that the following command will only activate the options in 32-bit.

```CFLAGS=$(getconf LFS_CFLAGS)```

See the link below for PHP LFS options.

- http://php.net/manual/en/intro.filesystem.php

When building armhf, I did not add LFS CFLAGS to Apache and MySQL because there is already the LFS option in the Apache and MySQL-Server build logs.

- armhf: https://launchpadlibrarian.net/398090788/buildlog_snap_ubuntu_xenial_armhf_nextcloud-for-32bit_BUILDING.txt.gz
- amd64: https://launchpad.net/~hwiorn/+snap/nextcloud-for-32bit/+build/381914/+files/buildlog_snap_ubuntu_xenial_amd64_nextcloud-for-32bit_BUILDING.txt.gz

Note that the nextcloud/docker armhf version also has the same problem ("fopen: Value too large for defined data type") because it uses the default PHP  without LFS provided by the docker hub.