### PR TITLE
snapcraft.yaml: Large file support in 32bit.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -195,6 +195,9 @@ parts:
       # Enable ldap.
       - --with-libdir=lib/ARCH_TRIPLET
       - --with-ldap
+
+      # Enable LFS(Large File Support) for 32bit architecture(e.g: i386 or i686, ARMv7).
+      - CFLAGS=-D_LARGEFILE_SOURCE=1 -D_FILE_OFFSET_BITS=64
     stage-packages:
       # These are only included here until the OS snap stabilizes
       - libxml2


### PR DESCRIPTION
It helps PHP handle files larger than 2GB in 32bit.

Fix #792