### PR TITLE
Doc Created: How to Migrate Away from nextcloud-snap

### DIFF
--- a/doc/HowTo-migrateFromSnapToManual.md
+++ b/doc/HowTo-migrateFromSnapToManual.md
@@ -12,6 +12,8 @@ The `nextcloud-snap` is very good.  For some situations it is the perfect soluti
 If you need to move from `nextcloud-snap` to Nextcloud server here are some notes:
 
 
+This document makes some assumptions.  It assumes you use `root` user to make changes.  You should not do this if you don't know what you're doing.  Then you will have to add 'sudo' to most of these commands.
+
 
 ## Install NextCloud
 
@@ -52,22 +54,31 @@ Copy `my-old-nextcloud.sql` file to the new server (`rsync` or `scp` etc)
 
 #### Allow larger innoDB
 
+Log in as root:
+
 `# mysql -u root -p`
+
+(If you skipped securing your mariaDB installation and you do not have a root password then skip the `-p`).
+
+mySQL commands:
 
 ```
 > SET GLOBAL innodb_file_format=Barracuda;
 > SET GLOBAL innodb_file_per_table=ON;
 > SET GLOBAL innodb_large_prefix=1;
+> quit;
 ```
 
-Now logout & login (to get the global values).
+You must `quit;` and then log in again to get the global values you set.
 
-#### create the new database:
+#### Create the new database:
 
 `> CREATE DATABASE nextcloud;`
 
 
 ## Populate NEW Database
+
+Exit mariaDB.  On the command line you type:
 
 `# mysql -u root -p nextcloud < my-old-nextcloud.sql`
 

--- a/doc/HowTo-migrateFromSnapToManual.md
+++ b/doc/HowTo-migrateFromSnapToManual.md
@@ -33,7 +33,7 @@ https://docs.nextcloud.com/server/14/admin_manual/installation/source_installati
 
 1. Extract nextcloud to `/var/www/nextcloud`
 
-2. (On Debian):
+2. Then chmod (example for Debian):
 
 `# chown -R www-data:www-data /var/www/nextcloud`
 
@@ -45,10 +45,10 @@ Run this on the OLD server:
 
 `# nextcloud.mysqldump > my-old-nextcloud.sql`
 
-Copy this file to the new server (`rsync` or `scp` etc)
+Copy `my-old-nextcloud.sql` file to the new server (`rsync` or `scp` etc)
 
 
-## Create Database on NEW server
+## Database on NEW server
 
 #### Allow larger innoDB
 
@@ -62,12 +62,12 @@ Copy this file to the new server (`rsync` or `scp` etc)
 
 Now logout & login (to get the global values).
 
-Now create the new database:
+#### create the new database:
 
 `> CREATE DATABASE nextcloud;`
 
 
-## Populate Database
+## Populate NEW Database
 
 `# mysql -u root -p nextcloud < my-old-nextcloud.sql`
 
@@ -79,7 +79,7 @@ Run this command from OLD server:
 `# rsync -avz --delete /var/snap/nextcloud/common/nextcloud/data/ root@your-new-server:/var/www/nextcloud/data/`
 
 
-## Migrate Certificates
+## Migrate SSL Certificates
 
 These instructions assume you are using LetsEncrypt.  The nextcloud-snap letsencrypt tool does not allow you to delete certificates but you can get around that this way.
 
@@ -90,21 +90,26 @@ These instructions assume you are using LetsEncrypt.  The nextcloud-snap letsenc
 
 3. Install the certificate with this command:
 
-`# certbot certonly -d <nextcloud.mydomain.com>`
+`# certbot certonly -d nextcloud.yourdomain.com`
 
+You can let the old certificates expire.  Just do nothing.
 
-You can let the old certificates expire.
-
-You can add this line to a cron job as root on the NEW server:
+You can add this line to a cron job as root on the NEW server to automatically update the certificate:
 
 `certbot renew --rsa-key-size 4096 --pre-hook "service apache2 stop" --post-hook "service apache2 start"`
 
 
 ## Apache2 configuration
 
+#### Some modules you will need:
+
 `# a2enmod ssl rewrite env headers mime dir`
 
-/etc/apache2/sites-enabled/nextcloud.conf:
+#### Sample conf file
+
+This file will redirect all traffic to https using the SSL certificate you created in the step above.
+
+`# vi /etc/apache2/sites-enabled/nextcloud.conf`
 
 ```
 <VirtualHost *:80>

--- a/doc/HowTo-migrateFromSnapToManual.md
+++ b/doc/HowTo-migrateFromSnapToManual.md
@@ -1,6 +1,6 @@
 # How to migrate from nextcloud-snap to Nextcloud 
 
-The nextcloud-snap is very good but there are problems:
+The `nextcloud-snap` is very good.  For some situations it is the perfect solution but there are problems:
 
 1. Little documentation for custom tools
 
@@ -9,7 +9,7 @@ The nextcloud-snap is very good but there are problems:
 3. Some current tools are limited (example: deleting letsencrypt certificates)
 
 
-If you need to move from nextcloud-snap to Nextcloud server here are some notes:
+If you need to move from `nextcloud-snap` to Nextcloud server here are some notes:
 
 
 
@@ -136,3 +136,11 @@ You can add this line to a cron job as root on the NEW server:
 </VirtualHost>
 
 ```
+
+`# service apache2 restart`
+
+## Done?
+
+I think this was everything I did to make it work (not including many things from the Intallation instructions at https://docs.nextcloud.com/server/14/admin_manual/installation/source_installation.html#ubuntu-installation-label for things like Redis, possibly other dependencies.
+
+What I learned is that the `nextcloud-snap` is more standardized than I thought.  But for some use cases it is not the best solution.  For many other situations it definitely is great.

--- a/doc/HowTo-migrateFromSnapToManual.md
+++ b/doc/HowTo-migrateFromSnapToManual.md
@@ -157,6 +157,8 @@ This file will redirect all traffic to https using the SSL certificate you creat
 
 ## Done?
 
-I think this was everything I did to make it work (not including many things from the Intallation instructions at https://docs.nextcloud.com/server/14/admin_manual/installation/source_installation.html#ubuntu-installation-label for things like Redis, possibly other dependencies.
+I think this was everything I did to make it work (not including many things from the Installation instructions at https://docs.nextcloud.com/server/14/admin_manual/installation/source_installation.html#ubuntu-installation-label for things like Redis, possibly other dependencies.
+
+When I logged on I saw my files including shared files.  The username and passwords were the same.  There were small problems with the Apps that came from new versions I think.  But mostly it was fine.
 
 What I learned is that the `nextcloud-snap` is more standardized than I thought.  But for some use cases it is not the best solution.  For many other situations it definitely is great.

--- a/doc/HowTo-migrateFromSnapToManual.md
+++ b/doc/HowTo-migrateFromSnapToManual.md
@@ -1,0 +1,138 @@
+# How to migrate from nextcloud-snap to Nextcloud 
+
+The nextcloud-snap is very good but there are problems:
+
+1. Little documentation for custom tools
+
+2. Slow and steady release schedule may not work for all clients
+
+3. Some current tools are limited (example: deleting letsencrypt certificates)
+
+
+If you need to move from nextcloud-snap to Nextcloud server here are some notes:
+
+
+
+## Install NextCloud
+
+Follow the terrible documentation on installing Nextcloud: 
+
+https://docs.nextcloud.com/server/14/admin_manual/installation/source_installation.html#ubuntu-installation-label
+
+### Suggestions:
+
+#### Some dependencies:
+
+`# apt-get install apache2 mariadb-server libapache2-mod-php php-gd php-json php-mysql php-curl php-mbstring php-intl php-mcrypt php-imagick php-xml php-zip php-fileinfo php-bz2 php-redis php-apcu ffmpeg`
+
+#### To secure the mariaDB installation:
+
+`# mysql_secure_installation`
+
+#### To avoid the /nextcloud folder in your URL
+
+1. Extract nextcloud to `/var/www/nextcloud`
+
+2. (On Debian):
+
+`# chown -R www-data:www-data /var/www/nextcloud`
+
+
+
+## Export Database from snap
+
+Run this on the OLD server:
+
+`# nextcloud.mysqldump > my-old-nextcloud.sql`
+
+Copy this file to the new server (`rsync` or `scp` etc)
+
+
+## Create Database on NEW server
+
+#### Allow larger innoDB
+
+`# mysql -u root -p`
+
+```
+> SET GLOBAL innodb_file_format=Barracuda;
+> SET GLOBAL innodb_file_per_table=ON;
+> SET GLOBAL innodb_large_prefix=1;
+```
+
+Now logout & login (to get the global values).
+
+Now create the new database:
+
+`> CREATE DATABASE nextcloud;`
+
+
+## Populate Database
+
+`# mysql -u root -p nextcloud < my-old-nextcloud.sql`
+
+
+## Move Files to New Server
+
+Run this command from OLD server:
+
+`# rsync -avz --delete /var/snap/nextcloud/common/nextcloud/data/ root@your-new-server:/var/www/nextcloud/data/`
+
+
+## Migrate Certificates
+
+These instructions assume you are using LetsEncrypt.  The nextcloud-snap letsencrypt tool does not allow you to delete certificates but you can get around that this way.
+
+
+1. Point your Nextcloud domain to the new server.
+
+2. Install certbot on the new server.
+
+3. Install the certificate with this command:
+
+`# certbot certonly -d <nextcloud.mydomain.com>`
+
+
+You can let the old certificates expire.
+
+You can add this line to a cron job as root on the NEW server:
+
+`certbot renew --rsa-key-size 4096 --pre-hook "service apache2 stop" --post-hook "service apache2 start"`
+
+
+## Apache2 configuration
+
+`# a2enmod ssl rewrite env headers mime dir`
+
+/etc/apache2/sites-enabled/nextcloud.conf:
+
+```
+<VirtualHost *:80>
+  DocumentRoot /var/www/nextcloud/
+  ServerName  nextcloud.yourdomain.com
+
+<Directory "/var/www/nextcloud/">
+  Require all granted
+  AllowOverride All
+  Options FollowSymLinks MultiViews
+</Directory>
+ 
+  RewriteEngine On
+  RewriteCond %{HTTPS} off 
+  RewriteRule (.*) https://%{SERVER_NAME}/$1 [R,L] 
+</VirtualHost>
+
+<VirtualHost *:443>
+        SSLEngine on
+        SSLCertificateFile /etc/letsencrypt/live/nextcloud.yourdomain.com/fullchain.pem
+        SSLCertificateKeyFile /etc/letsencrypt/live/nextcloud.yourdomain.com/privkey.pem
+        <Directory /var/www/nextcloud/>
+                AllowOverride All 
+                Require all granted
+                Options FollowSymLinks MultiViews
+        </Directory>
+        DocumentRoot /var/www/nextcloud/
+        ServerName nextcloud.yourdomain.com
+</VirtualHost>
+
+```


### PR DESCRIPTION
`nextcloud-snap` is very good.  But there are use cases when it is not the best solution.  Because of the way the snap is listed on the NC website as the first option many people will use it without knowing this.  Or a user might grow past the snap and want more direct control over the installation.

Because of this I documented my successful migration away from `nextcloud-snap` to Nextcloud server on Ubuntu 16.04 and I request it to be into the `nextcloud-snap` repository to answer these tickets (one is mine):

https://github.com/nextcloud/nextcloud-snap/issues/735
https://github.com/nextcloud/nextcloud-snap/issues/788