### PR TITLE
ci: enable daily v14 and v15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,24 +64,6 @@ jobs:
           # Run the tests
           command: ./.circleci/runtests.sh
 
-  test-daily-v12:
-    working_directory: ~/nextcloud-snap
-    machine: true
-    steps:
-      - checkout
-
-      - run:
-          # Install the snap and create an admin user
-          command: |
-            sudo apt update -qq
-            sudo apt install -y snapd
-            sudo snap install nextcloud --channel=12/edge
-            sudo nextcloud.manual-install admin admin
-
-      - run:
-          # Run the tests
-          command: ./.circleci/runtests.sh
-
   test-daily-v13:
     working_directory: ~/nextcloud-snap
     machine: true
@@ -94,6 +76,42 @@ jobs:
             sudo apt update -qq
             sudo apt install -y snapd
             sudo snap install nextcloud --channel=13/edge
+            sudo nextcloud.manual-install admin admin
+
+      - run:
+          # Run the tests
+          command: ./.circleci/runtests.sh
+
+  test-daily-v14:
+    working_directory: ~/nextcloud-snap
+    machine: true
+    steps:
+      - checkout
+
+      - run:
+          # Install the snap and create an admin user
+          command: |
+            sudo apt update -qq
+            sudo apt install -y snapd
+            sudo snap install nextcloud --channel=14/edge
+            sudo nextcloud.manual-install admin admin
+
+      - run:
+          # Run the tests
+          command: ./.circleci/runtests.sh
+
+  test-daily-v15:
+    working_directory: ~/nextcloud-snap
+    machine: true
+    steps:
+      - checkout
+
+      - run:
+          # Install the snap and create an admin user
+          command: |
+            sudo apt update -qq
+            sudo apt install -y snapd
+            sudo snap install nextcloud --channel=15/edge
             sudo nextcloud.manual-install admin admin
 
       - run:
@@ -116,17 +134,6 @@ workflows:
 
     jobs: [test-daily-master]
 
-  daily-v12:
-    triggers:
-      - schedule:
-          # 0700 UTC == 0000 PSC
-          cron: "0 7 * * *"
-          filters:
-            branches:
-              only: develop
-
-    jobs: [test-daily-v12]
-
   daily-v13:
     triggers:
       - schedule:
@@ -137,3 +144,25 @@ workflows:
               only: develop
 
     jobs: [test-daily-v13]
+
+  daily-v14:
+    triggers:
+      - schedule:
+          # 0700 UTC == 0000 PSC
+          cron: "0 7 * * *"
+          filters:
+            branches:
+              only: develop
+
+    jobs: [test-daily-v14]
+
+  daily-v15:
+    triggers:
+      - schedule:
+          # 0700 UTC == 0000 PSC
+          cron: "0 7 * * *"
+          filters:
+            branches:
+              only: develop
+
+    jobs: [test-daily-v15]

--- a/.travis/cron.sh
+++ b/.travis/cron.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 latest_master_url="https://download.nextcloud.com/server/daily/latest-master.tar.bz2"
-latest_stable12_url="https://download.nextcloud.com/server/daily/latest-stable12.tar.bz2"
 latest_stable13_url="https://download.nextcloud.com/server/daily/latest-stable13.tar.bz2"
+latest_stable14_url="https://download.nextcloud.com/server/daily/latest-stable14.tar.bz2"
+latest_stable15_url="https://download.nextcloud.com/server/daily/latest-stable15.tar.bz2"
 
 rewrite_snapcraft_yaml()
 {
@@ -36,12 +37,17 @@ request_build \
 	"latest-master" "$latest_master_url" "master-$today" \
 	"From CI: Use Nextcloud latest master"
 
-echo "Requesting build of latest 12..."
-request_build \
-	"latest-12" "$latest_stable12_url" "12-$today" \
-	"From CI: Use Nextcloud latest 12"
-
 echo "Requesting build of latest 13..."
 request_build \
 	"latest-13" "$latest_stable13_url" "13-$today" \
 	"From CI: Use Nextcloud latest 13"
+
+echo "Requesting build of latest 14..."
+request_build \
+	"latest-14" "$latest_stable14_url" "14-$today" \
+	"From CI: Use Nextcloud latest 14"
+
+echo "Requesting build of latest 15..."
+request_build \
+	"latest-15" "$latest_stable15_url" "15-$today" \
+	"From CI: Use Nextcloud latest 15"


### PR DESCRIPTION
This PR resolves #825 by disabling daily v12 (it's no longer supported) and enabling daily v14 and v15.