### PR TITLE
nextcloud: disable updatenotification before upgrade

### DIFF
--- a/src/nextcloud/bin/setup-nextcloud
+++ b/src/nextcloud/bin/setup-nextcloud
@@ -45,6 +45,11 @@ else
 	occ config:system:set redis port --value=0 --type=integer
 	occ config:system:set memcache.locking --value="\OC\Memcache\Redis" --type=string
 	occ config:system:set memcache.local --value="\OC\Memcache\Redis" --type=string
+
+	# It's possible for the updatenotification app to be installed (see
+	# https://github.com/nextcloud/nextcloud-snap/issues/838), and it'll
+	# interfere with the upgrade to v14. Disable it now.
+	occ app:disable updatenotification
 fi
 
 # Finally, make sure nextcloud is up to date. The return code of the upgrade


### PR DESCRIPTION
It seems that the updatenotification app is still installed for some folks even though it's been disabled in the snap since v10. It prevents the upgrade to v14: this PR fixes #838 by disabling it before attempting the upgrade.