### PR TITLE
php: enable large file support on 32-bit systems

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -190,7 +190,6 @@ parts:
       - --with-curl
       - --with-openssl
       - --with-bz2
-      - --with-mcrypt
       - --enable-exif
       - --enable-intl
       - --enable-pcntl
@@ -200,7 +199,7 @@ parts:
       - --enable-ftp
 
       # Enable ldap.
-      - --with-libdir=lib/ARCH_TRIPLET
+      - --with-libdir=lib/$SNAPCRAFT_ARCH_TRIPLET
       - --with-ldap
     stage-packages:
       # These are only included here until the OS snap stabilizes


### PR DESCRIPTION
This PR fixes #792 by enabling large file support for PHP on 32-bit systems. It also enables it for any extensions being built.

Please test this PR using the `beta/pr-862` channel:

    $ sudo snap install nextcloud --channel=beta/pr-862

Or, if you already have it installed:

    $ sudo snap refresh nextcloud --channel=beta/pr-862