### PR TITLE
nextcloud: update to 15.0.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -158,8 +158,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-14.0.6.tar.bz2
-    source-checksum: sha256/1a739b5c4a633d15e68d1db31f785c2e5926b877e165af62f740837077e2f45f
+    source: https://download.nextcloud.com/server/releases/nextcloud-15.0.2.tar.bz2
+    source-checksum: sha256/c1f4cc33e39994ddbe6777370b62c30b7ae52136a0530c0b9922770803ca0fea
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess
@@ -250,6 +250,7 @@ parts:
     source: src/nextcloud/
     organize:
       config/: htdocs/config/
+    stage-packages: [jq]
 
   # Download the boost headers for MySQL. Note that the version used may need to
   # be updated if the version of MySQL changes.
@@ -374,6 +375,10 @@ parts:
     plugin: dump
     source: src/import-export
     stage-packages: [rsync]
+
+  common:
+    plugin: dump
+    source: src/common/
 
   hooks:
     plugin: dump

--- a/src/apache/utilities/apache-utilities
+++ b/src/apache/utilities/apache-utilities
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# shellcheck source=src/common/utilities/common-utilities
+. "$SNAP/utilities/common-utilities"
+
 DEFAULT_HTTP_PORT="80"
 DEFAULT_HTTPS_PORT="443"
 export APACHE_PIDFILE="/tmp/pids/httpd.pid"
@@ -33,13 +36,7 @@ apache_is_running()
 
 wait_for_apache()
 {
-	if ! apache_is_running; then
-		printf "Waiting for Apache... "
-		while ! apache_is_running; do
-			sleep 1
-		done
-		printf "done\n"
-	fi
+	wait_for_command "Waiting for Apache" apache_is_running
 }
 
 apache_pid()

--- a/src/common/utilities/common-utilities
+++ b/src/common/utilities/common-utilities
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+stdout_is_a_terminal()
+{
+	[ -t 1 ]
+}
+
+stderr_is_a_terminal()
+{
+	[ -t 2 ]
+}
+
+run_command()
+{
+	# Ideally we could output these all on one line, but that only works with a
+	# terminal. Support both.
+	if stdout_is_a_terminal; then
+		printf "%s... " "$1"
+	else
+		echo "$1..."
+	fi
+
+	shift
+	if output="$("$@" 2>&1)"; then
+		echo "done"
+		return 0
+	else
+		echo "error"
+		echo "$output"
+		return 1
+	fi
+}
+
+wait_for_command()
+{
+	message="$1"
+	shift
+	if ! "$@"; then
+		# Ideally we could output these all on one line, but that only works with a
+		# terminal. Support both.
+		if stdout_is_a_terminal; then
+			printf "%s... " "$message"
+		else
+			echo "$message..."
+		fi
+		while ! "$@"; do
+			sleep 1
+		done
+		echo "done"
+	fi
+}
+
+enable_maintenance_mode()
+{
+	run_command "Enabling maintenance mode" occ maintenance:mode --on
+}
+
+disable_maintenance_mode()
+{
+	run_command "Disabling maintenance mode" occ maintenance:mode --off
+}

--- a/src/import-export/bin/export-data
+++ b/src/import-export/bin/export-data
@@ -9,6 +9,8 @@ fi
 . "$SNAP/utilities/nextcloud-utilities"
 # shellcheck source=src/mysql/utilities/mysql-utilities
 . "$SNAP/utilities/mysql-utilities"
+# shellcheck source=src/common/utilities/common-utilities
+. "$SNAP/utilities/common-utilities"
 
 # shellcheck disable=SC2119
 wait_for_mysql
@@ -76,29 +78,6 @@ export_data()
 		echo "Unable to export data"
 		exit 1
 	fi
-}
-
-run_command()
-{
-	printf "%s... " "$2"
-	if output="$(eval "$1" 2>&1)"; then
-		echo "done"
-		return 0;
-	else
-		echo "error"
-		echo "$output"
-		return 1;
-	fi
-}
-
-enable_maintenance_mode()
-{
-	run_command "occ maintenance:mode --on" "Enabling maintenance mode"
-}
-
-disable_maintenance_mode()
-{
-	run_command "occ maintenance:mode --off" "Disabling maintenance mode"
 }
 
 do_export_apps=false

--- a/src/import-export/bin/import-data
+++ b/src/import-export/bin/import-data
@@ -9,6 +9,8 @@ fi
 . "$SNAP/utilities/nextcloud-utilities"
 # shellcheck source=src/mysql/utilities/mysql-utilities
 . "$SNAP/utilities/mysql-utilities"
+# shellcheck source=src/common/utilities/common-utilities
+. "$SNAP/utilities/common-utilities"
 
 # shellcheck disable=SC2119
 wait_for_mysql
@@ -35,7 +37,7 @@ import_apps()
 {
 	backup_dir="${1%/}"
 	apps_backup="${backup_dir}/apps"
-	run_command "rm -rf \"$SNAP_DATA/nextcloud/extra-apps\"" "Clearing existing non-default apps"
+	run_command "Clearing existing non-default apps" rm -rf "$SNAP_DATA/nextcloud/extra-apps"
 	echo "Importing apps..."
 	if ! rsync -ah --info=progress2 "$apps_backup/" "$SNAP_DATA/nextcloud/extra-apps"; then
 		echo "Unable to import apps"
@@ -49,12 +51,11 @@ import_database()
 	database_backup="${backup_dir}/database.sql"
 
 	# First, drop the database (if any)
-	run_command "run-mysql -e \"DROP DATABASE nextcloud\"" \
-	            "Dropping existing database"
-	run_command "run-mysql -e \"CREATE DATABASE nextcloud\"" \
-	            "Creating new database"
-	run_command "run-mysql -e \"GRANT ALL PRIVILEGES ON nextcloud.* TO 'nextcloud'@'localhost'\"" \
-	            "Granting database privileges to existing user"
+	run_command "Dropping existing database" run-mysql -e "DROP DATABASE nextcloud"
+	run_command "Creating new database" run-mysql -e "CREATE DATABASE nextcloud"
+	run_command "Granting database privileges to existing user" \
+	            run-mysql -e "GRANT ALL PRIVILEGES ON nextcloud.* TO 'nextcloud'@'localhost'"
+
 
 	# Now restore the database
 	echo "Importing database..."
@@ -83,35 +84,12 @@ import_data()
 {
 	backup_dir="${1%/}"
 	data_backup="${backup_dir}/data"
-	run_command "rm -rf \"$NEXTCLOUD_DATA_DIR\"" "Clearing existing data"
+	run_command "Clearing existing data" rm -rf "$NEXTCLOUD_DATA_DIR"
 	echo "Importing data..."
 	if ! rsync -ah --info=progress2 "$data_backup/" "$NEXTCLOUD_DATA_DIR"; then
 		echo "Unable to import data"
 		exit 1
 	fi
-}
-
-run_command()
-{
-	printf "%s... " "$2"
-	if output="$(eval "$1" 2>&1)"; then
-		echo "done"
-		return 0;
-	else
-		echo "error"
-		echo "$output"
-		return 1;
-	fi
-}
-
-enable_maintenance_mode()
-{
-	run_command "occ maintenance:mode --on" "Enabling maintenance mode"
-}
-
-disable_maintenance_mode()
-{
-	run_command "occ maintenance:mode --off" "Disabling maintenance mode"
 }
 
 do_import_apps=false

--- a/src/mysql/utilities/mysql-utilities
+++ b/src/mysql/utilities/mysql-utilities
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# shellcheck source=src/common/utilities/common-utilities
+. "$SNAP/utilities/common-utilities"
+
 export MYSQL_PIDFILE="/tmp/pids/mysql.pid"
 export MYSQL_SOCKET="/tmp/sockets/mysql.sock"
 export NEXTCLOUD_PASSWORD_FILE="$SNAP_DATA/mysql/nextcloud_password"
@@ -7,8 +10,10 @@ MYSQL_SETUP_LOCKFILE="/tmp/locks/mysql-setup"
 
 mkdir -p "$(dirname "$MYSQL_PIDFILE")"
 mkdir -p "$(dirname "$MYSQL_SOCKET")"
+mkdir -p "$(dirname "$MYSQL_SETUP_LOCKFILE")"
 chmod 750 "$(dirname "$MYSQL_PIDFILE")"
 chmod 750 "$(dirname "$MYSQL_SOCKET")"
+chmod 750 "$(dirname "$MYSQL_SETUP_LOCKFILE")"
 
 mysql_is_running()
 {
@@ -21,13 +26,7 @@ wait_for_mysql()
 {
 	# Arguments:
 	#  -f: Force the check, i.e. ignore if it's currently in setup
-	if ! mysql_is_running "$@"; then
-		printf "Waiting for MySQL... "
-		while ! mysql_is_running "$@"; do
-			sleep 1
-		done
-		printf "done\n"
-	fi
+	wait_for_command "Waiting for MySQL" mysql_is_running "$@"
 }
 
 mysql_setup_running()
@@ -47,7 +46,7 @@ set_mysql_setup_not_running()
 
 mysql_pid()
 {
-	if mysql_is_running; then
+	if mysql_is_running ""; then
 		cat "$MYSQL_PIDFILE"
 	else
 		echo "Unable to get MySQL PID as it's not yet running" >&2

--- a/src/nextcloud/bin/nextcloud-fixer
+++ b/src/nextcloud/bin/nextcloud-fixer
@@ -2,9 +2,34 @@
 
 # shellcheck source=src/apache/utilities/apache-utilities
 . "$SNAP/utilities/apache-utilities"
+# shellcheck source=src/common/utilities/common-utilities
+. "$SNAP/utilities/common-utilities"
+# shellcheck source=src/nextcloud/utilities/nextcloud-utilities
+. "$SNAP/utilities/nextcloud-utilities"
 
 # By waiting for Apache we ensure that Nextcloud is setup and fully-updated
 wait_for_apache
 
-# This command can be run without putting Nextcloud into maintenance mode
-occ db:add-missing-indices
+if nextcloud_is_installed; then
+	# This command can be run without putting Nextcloud into maintenance mode
+	occ db:add-missing-indices --no-interaction
+
+	# Unfortunately convert-filecache-bigint requires that Nextcloud be in maintenance
+	# mode, and can take some time.
+	if ! enable_maintenance_mode; then
+		echo "Unable to enter maintenance mode" >&2
+		sleep 10 # Give it a few seconds before bailing so systemd doesn't throttle
+		exit 1
+	fi
+	trap 'disable_maintenance_mode' EXIT
+
+	occ db:convert-filecache-bigint --no-interaction
+else
+	wait_for_nextcloud_to_be_installed
+
+	# Technically convert-filecache-bigint should be run under maintenance mode, but
+	# there really isn't anything to go wrong on a fresh install, and the UX of enabling
+	# maintenance mode as soon as an admin account is created is awful.
+	occ db:add-missing-indices --no-interaction
+	occ db:convert-filecache-bigint --no-interaction
+fi

--- a/src/nextcloud/utilities/nextcloud-utilities
+++ b/src/nextcloud/utilities/nextcloud-utilities
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# shellcheck source=src/common/utilities/common-utilities
+. "$SNAP/utilities/common-utilities"
+
 export NEXTCLOUD_CONFIG_DIR="$SNAP_DATA/nextcloud/config"
 export NEXTCLOUD_DATA_DIR="$SNAP_COMMON/nextcloud/data"
 DEFAULT_CRONJOB_INTERVAL="15m"
@@ -11,13 +14,20 @@ nextcloud_is_configured()
 
 wait_for_nextcloud_to_be_configured()
 {
-	if ! nextcloud_is_configured; then
-		printf "Waiting for Nextcloud to be configured... "
-		while ! nextcloud_is_configured; do
-			sleep 1
-		done
-		printf "done\n"
-	fi
+	wait_for_command "Waiting for Nextcloud to be configured" nextcloud_is_configured
+}
+
+# Nextcloud doesn't consider itself "installed" until the admin account has been created
+nextcloud_is_installed()
+{
+	# Urgh, occ still prints text warnings even with JSON output. Thus fromjson?.
+	installed="$(occ status --output=json | jq -R 'fromjson? | .installed')"
+	[ "$installed" = "true" ]
+}
+
+wait_for_nextcloud_to_be_installed()
+{
+	wait_for_command "Waiting for Nextcloud to be installed" nextcloud_is_installed
 }
 
 cronjob_interval()

--- a/src/php/utilities/php-utilities
+++ b/src/php/utilities/php-utilities
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# shellcheck source=src/common/utilities/common-utilities
+. "$SNAP/utilities/common-utilities"
+
 DEFAULT_MEMORY_LIMIT="512M"
 export PHP_FPM_PIDFILE="/tmp/pids/php-fpm.pid"
 export PHP_FPM_SOCKET="/tmp/sockets/php-fpm.sock"
@@ -35,13 +38,7 @@ php_is_running()
 
 wait_for_php()
 {
-	if ! php_is_running; then
-		printf "Waiting for PHP... "
-		while ! php_is_running; do
-			sleep 1
-		done
-		printf "done\n"
-	fi
+	wait_for_command "Waiting for PHP" php_is_running
 }
 
 php_pid()

--- a/src/redis/utilities/redis-utilities
+++ b/src/redis/utilities/redis-utilities
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# shellcheck source=src/common/utilities/common-utilities
+. "$SNAP/utilities/common-utilities"
+
 export REDIS_PIDFILE="/tmp/pids/redis.pid"
 export REDIS_SOCKET="/tmp/sockets/redis.sock"
 
@@ -15,13 +18,7 @@ redis_is_running()
 
 wait_for_redis()
 {
-	if ! redis_is_running; then
-		printf "Waiting for redis... "
-		while ! redis_is_running; do
-			sleep 1
-		done
-		printf "done\n"
-	fi
+	wait_for_command "Waiting for redis" redis_is_running
 }
 
 redis_pid()


### PR DESCRIPTION
This PR resolves #812 by updating Nextcloud to the latest v15 release. It also adds logic to nextcloud-fixer to run the `convert-filecache-bigint` job automatically. Note that as of v15, Nextcloud shows a warning that imagick is not installed. This is unfortunate, but expected in the snap.

Please test this PR with the `beta/pr-865` channel:

    $ sudo snap install nextcloud --channel=beta/pr-865

Or, if you already have it installed:

    $ sudo snap refresh nextcloud --channel=beta/pr-865