### PR TITLE
nextcloud-fixer: disable theming app on new installs

### DIFF
--- a/src/nextcloud/bin/nextcloud-fixer
+++ b/src/nextcloud/bin/nextcloud-fixer
@@ -27,6 +27,11 @@ if nextcloud_is_installed; then
 else
 	wait_for_nextcloud_to_be_installed
 
+	# Disable the theming app. It requires imagick (which the snap doesn't ship) and
+	# displays a warning if it's not installed. This way, the warning is only shown if
+	# someone needs and enables the theming app.
+	run_command "Disabling theming by default" occ app:disable theming
+
 	# Technically convert-filecache-bigint should be run under maintenance mode, but
 	# there really isn't anything to go wrong on a fresh install, and the UX of enabling
 	# maintenance mode as soon as an admin account is created is awful.


### PR DESCRIPTION
This PR resolves #875 since disabling the theming app prevents the warning about imagick being required unless someone requires and enables the app.

Please test this PR using the `beta/pr-876` channel:

    $ sudo snap install nextcloud --channel=beta/pr-876

Or, if you already have it installed:

    $ sudo snap refresh nextcloud --channel=beta/pr-876

On a fresh install, the theming app should be disabled and no warning should appear. One should still be able to enable it and use theming, but then the warning appears, which actually seems fine at that point. On an upgrade from `stable`, the theming app should still be enabled and the warning _should_ appear.