### PR TITLE
nextcloud: update to 15.0.4

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -158,8 +158,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-15.0.2.tar.bz2
-    source-checksum: sha256/c1f4cc33e39994ddbe6777370b62c30b7ae52136a0530c0b9922770803ca0fea
+    source: https://download.nextcloud.com/server/releases/nextcloud-15.0.4.tar.bz2
+    source-checksum: sha256/f87db047c174f563e391a22c959d9ace767ca14ef0f97fc394f3061fc63d8f77
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #889 by updating Nextcloud to the latest v15 release.

Please test this PR using the `beta/pr-890` channel:

    $ sudo snap install nextcloud --channel=beta/pr-890

Or, if you already have it installed:

    $ sudo snap refresh nextcloud --channel=beta/pr-890