### PR TITLE
apache: don't redirect Let's Encrypt to HTTPS 

### DIFF
--- a/src/apache/conf/ssl.conf
+++ b/src/apache/conf/ssl.conf
@@ -77,6 +77,8 @@ SSLRandomSeed connect file:/dev/urandom 512
     # Disable HTTP TRACK method.
     RewriteCond %{REQUEST_METHOD} ^TRACK
     RewriteRule .* - [R=405,L]
+    # Do not redirect Let's Encrypt challenge requests
+    RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/.*
     # Redirect everything else to HTTPS
     RewriteRule ^ https://%{SERVER_NAME}:${HTTPS_PORT}%{REQUEST_URI} [END,QSA,R=permanent]
 </VirtualHost>

--- a/tests/spec/spec_helper.rb
+++ b/tests/spec/spec_helper.rb
@@ -142,7 +142,7 @@ RSpec.configure do |config|
 		RSpec.configuration.headless.destroy
 	end
 
-	config.after(:all) do
+	config.after(:each) do
 		# After each test, make sure the ports are reset
 		`sudo snap set nextcloud ports.http=80 ports.https=443`
 		expect($?.to_i).to eq 0
@@ -165,7 +165,7 @@ RSpec.configure do |config|
 		# Make sure any and all backups are removed
 		`sudo rm -rf /var/snap/nextcloud/common/backups`
 
-		# Make sure we're usin the normal, HTTP host again
+		# Make sure we're using the normal, HTTP host again
 		Capybara.app_host = 'http://localhost'
 	end
 


### PR DESCRIPTION
Not redirecting Lets-Encrypt challenge requests in ssl.conf.

Made this change referencing the [RewriteRule documentation](https://httpd.apache.org/docs/2.4/mod/mod_rewrite.html#RewriteRule).

**I didn't find a way to test this change locally since I'm using Ubuntu 18.04**. Could someone who has a better setup test this?

I think it's possible to write a test for this as well, but I didn't write one since I couldn't get the snap to build.