### PR TITLE
Release 15.0.5snap1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v 15.0.5snap1
+  - nextcloud: update to 15.0.5
+  - mysql: update to 5.7.25
+  - redis: update to 4.0.13
+
 v 15.0.4snap1
   - nextcloud: update to 15.0.4
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Nextcloud server packaged as a snap. It consists of:
 
-- Nextcloud 15.0.4
+- Nextcloud 15.0.5
 - Apache 2.4
 - PHP 7.2
 - MySQL 5.7

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -158,8 +158,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-15.0.4.tar.bz2
-    source-checksum: sha256/f87db047c174f563e391a22c959d9ace767ca14ef0f97fc394f3061fc63d8f77
+    source: https://download.nextcloud.com/server/releases/nextcloud-15.0.5.tar.bz2
+    source-checksum: sha256/4661869b797a340cd967abb3dbe6931b375434e0a44480346a27ccd73250b988
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -227,8 +227,8 @@ parts:
 
   redis:
     plugin: redis
-    source: http://download.redis.io/releases/redis-4.0.11.tar.gz
-    source-checksum: sha256/fc53e73ae7586bcdacb4b63875d1ff04f68c5474c1ddeda78f00e5ae2eed1bbb
+    source: http://download.redis.io/releases/redis-4.0.13.tar.gz
+    source-checksum: sha256/17d955227966dcd68590be6139e5fe7f2d19fc4fb7334248a904ea9cdd30c1d4
 
   redis-customizations:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -272,7 +272,7 @@ parts:
   mysql:
     plugin: cmake
     source: https://github.com/mysql/mysql-server.git
-    source-tag: mysql-5.7.22
+    source-tag: mysql-5.7.25
     source-depth: 1
     override-pull: |
       snapcraftctl pull


### PR DESCRIPTION
- nextcloud: update to 15.0.5
- mysql: update to 5.7.25
- redis: update to 4.0.13

Please read [this wiki topic](https://github.com/nextcloud/nextcloud-snap/wiki/Testing-pull-requests) for how to test/evaluate this PR.