### PR TITLE
apache: disable TLS 1.0 and 1.1 and strengthen ciphers

### DIFF
--- a/src/apache/conf/ssl.conf
+++ b/src/apache/conf/ssl.conf
@@ -40,8 +40,8 @@ LoadModule ssl_module modules/mod_ssl.so
 #   Disable SSLv3 by default (cf. RFC 7525 3.1.1).  TLSv1 (1.0) should be
 #   disabled as quickly as practical.  By the end of 2016, only the TLSv1.2
 #   protocol or later should remain in use.
-SSLProtocol all -SSLv3
-SSLProxyProtocol all -SSLv3
+SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
+SSLProxyProtocol all -SSLv3 -TLSv1 -TLSv1.1
 
 #   Pass Phrase Dialog:
 #   Configure the pass phrase gathering process.
@@ -93,7 +93,11 @@ SSLRandomSeed connect file:/dev/urandom 512
 
     SSLEngine on
     SSLHonorCipherOrder On
-    SSLCipherSuite ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS;
+    SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:DHE-RSA-AES256-GCM-SHA384
+
+    # Ensure perfect forward secrecy isn't compromised; the server doesn't
+    # necessarily restart regularly.
+    SSLSessionTickets off
 
     SSLCertificateFile      ${SNAP_DATA}/certs/live/cert.pem
     SSLCertificateKeyFile   ${SNAP_DATA}/certs/live/privkey.pem


### PR DESCRIPTION
Security is always a balancing act. The current cipher list in the snap prioritizes older clients while maintaining reasonable security for all. These settings are routinely verified using both [SSL Labs](https://www.ssllabs.com/ssltest/) and [testssl.sh](https://testssl.sh/), and the snap continues to get an A+ rating on SSL Labs. However, one of the ways we support older clients is by still using TLS 1.0 and 1.1, and also using CBC ciphers.

It's been a few years, and as several folks have pointed out, it's time to re-evaluate this balancing act for the cipher list in particular. To go through this exercise, I started with the modern config from Mozilla's [config generator](https://mozilla.github.io/server-side-tls/ssl-config-generator/), locked it down enough that nothing could possibly complain, and then loosened it until I was reasonably happy with the clients still supported while still ensuring that neither analysis tool took issue with it. Our support client list has gone from this:

![Screenshot from 2019-03-16 12-29-40](https://user-images.githubusercontent.com/946674/54480808-6ab9ed80-47ea-11e9-899c-eb84781c2e17.png)

To this:

![Screenshot from 2019-03-16 18-45-55](https://user-images.githubusercontent.com/946674/54484073-eb451200-481b-11e9-942e-fee85dab02c3.png)

You'll notice that this greatly reduces the number of clients supported, but in my opinion they are old enough it shouldn't be an issue. I did massage the cipher suite to make sure we continued to support Internet Explorer on Windows 7 (such users are still [fairly well-represented](https://www.w3counter.com/globalstats.php) in today's statistics), and I'm more or less happy with this. **Please speak up if you're not**. I will halt this if anyone takes issue with it, and it will be easy to roll back in the future as well if it ends up being a scream test.

Anyway, both SSL Labs and testssl.sh are happy, and we've managed to get rid of TLS 1.0 and 1.1, limit ciphers to those that support forward secrecy, well as get rid of CBC ciphers. As a result, this PR resolves #616 and also resolves #737.