### PR TITLE
Release 15.0.5snap2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v 15.0.5snap2
+  - apache: disable TLS 1.0 and 1.1 and strengthen ciphers
+  - apache: don't redirect Let's Encrypt to HTTPS
+  - php: update to 7.2.16
+
 v 15.0.5snap1
   - nextcloud: update to 15.0.5
   - mysql: update to 5.7.25

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -172,8 +172,8 @@ parts:
 
   php:
     plugin: php
-    source: https://php.net/get/php-7.2.14.tar.bz2/from/this/mirror
-    source-checksum: sha256/f56132d248c7bf1e0efc8a680a4b598d6ff73fc6b9c84b5d7b539ad8db7a6597
+    source: https://php.net/get/php-7.2.16.tar.bz2/from/this/mirror
+    source-checksum: sha256/2c0ad10053d58694cd14323248ecd6d9ba71d2733d160973c356ad01d09e7f38
     source-type: tar
     install-via: prefix
     configflags:

--- a/src/apache/conf/ssl.conf
+++ b/src/apache/conf/ssl.conf
@@ -77,6 +77,8 @@ SSLRandomSeed connect file:/dev/urandom 512
     # Disable HTTP TRACK method.
     RewriteCond %{REQUEST_METHOD} ^TRACK
     RewriteRule .* - [R=405,L]
+    # Do not redirect Let's Encrypt challenge requests
+    RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/.*
     # Redirect everything else to HTTPS
     RewriteRule ^ https://%{SERVER_NAME}:${HTTPS_PORT}%{REQUEST_URI} [END,QSA,R=permanent]
 </VirtualHost>

--- a/src/apache/conf/ssl.conf
+++ b/src/apache/conf/ssl.conf
@@ -40,8 +40,8 @@ LoadModule ssl_module modules/mod_ssl.so
 #   Disable SSLv3 by default (cf. RFC 7525 3.1.1).  TLSv1 (1.0) should be
 #   disabled as quickly as practical.  By the end of 2016, only the TLSv1.2
 #   protocol or later should remain in use.
-SSLProtocol all -SSLv3
-SSLProxyProtocol all -SSLv3
+SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
+SSLProxyProtocol all -SSLv3 -TLSv1 -TLSv1.1
 
 #   Pass Phrase Dialog:
 #   Configure the pass phrase gathering process.
@@ -93,7 +93,11 @@ SSLRandomSeed connect file:/dev/urandom 512
 
     SSLEngine on
     SSLHonorCipherOrder On
-    SSLCipherSuite ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS;
+    SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:DHE-RSA-AES256-GCM-SHA384
+
+    # Ensure perfect forward secrecy isn't compromised; the server doesn't
+    # necessarily restart regularly.
+    SSLSessionTickets off
 
     SSLCertificateFile      ${SNAP_DATA}/certs/live/cert.pem
     SSLCertificateKeyFile   ${SNAP_DATA}/certs/live/privkey.pem

--- a/tests/spec/spec_helper.rb
+++ b/tests/spec/spec_helper.rb
@@ -142,7 +142,7 @@ RSpec.configure do |config|
 		RSpec.configuration.headless.destroy
 	end
 
-	config.after(:all) do
+	config.after(:each) do
 		# After each test, make sure the ports are reset
 		`sudo snap set nextcloud ports.http=80 ports.https=443`
 		expect($?.to_i).to eq 0
@@ -165,7 +165,7 @@ RSpec.configure do |config|
 		# Make sure any and all backups are removed
 		`sudo rm -rf /var/snap/nextcloud/common/backups`
 
-		# Make sure we're usin the normal, HTTP host again
+		# Make sure we're using the normal, HTTP host again
 		Capybara.app_host = 'http://localhost'
 	end
 


### PR DESCRIPTION
- apache: disable TLS 1.0 and 1.1 and strengthen ciphers
- apache: don't redirect Let's Encrypt to HTTPS
- php: update to 7.2.16