### PR TITLE
ci: disable v13 dailies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,24 +64,6 @@ jobs:
           # Run the tests
           command: ./.circleci/runtests.sh
 
-  test-daily-v13:
-    working_directory: ~/nextcloud-snap
-    machine: true
-    steps:
-      - checkout
-
-      - run:
-          # Install the snap and create an admin user
-          command: |
-            sudo apt update -qq
-            sudo apt install -y snapd
-            sudo snap install nextcloud --channel=13/edge
-            sudo nextcloud.manual-install admin admin
-
-      - run:
-          # Run the tests
-          command: ./.circleci/runtests.sh
-
   test-daily-v14:
     working_directory: ~/nextcloud-snap
     machine: true
@@ -133,17 +115,6 @@ workflows:
               only: develop
 
     jobs: [test-daily-master]
-
-  daily-v13:
-    triggers:
-      - schedule:
-          # 0700 UTC == 0000 PSC
-          cron: "0 7 * * *"
-          filters:
-            branches:
-              only: develop
-
-    jobs: [test-daily-v13]
 
   daily-v14:
     triggers:

--- a/.travis/cron.sh
+++ b/.travis/cron.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 latest_master_url="https://download.nextcloud.com/server/daily/latest-master.tar.bz2"
-latest_stable13_url="https://download.nextcloud.com/server/daily/latest-stable13.tar.bz2"
 latest_stable14_url="https://download.nextcloud.com/server/daily/latest-stable14.tar.bz2"
 latest_stable15_url="https://download.nextcloud.com/server/daily/latest-stable15.tar.bz2"
 
@@ -36,11 +35,6 @@ echo "Requesting build of latest master..."
 request_build \
 	"latest-master" "$latest_master_url" "master-$today" \
 	"From CI: Use Nextcloud latest master"
-
-echo "Requesting build of latest 13..."
-request_build \
-	"latest-13" "$latest_stable13_url" "13-$today" \
-	"From CI: Use Nextcloud latest 13"
 
 echo "Requesting build of latest 14..."
 request_build \


### PR DESCRIPTION
This PR resolves #964 by removing the generation and testing of v13 daily builds. v13 is no longer supported.