### PR TITLE
nextcloud: update to 16.0.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -158,8 +158,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-15.0.7.tar.bz2
-    source-checksum: sha256/3e6158951fa72010ccd50dbeac05d8df162183f7bbc62a1c6c89ed7081fa9d49
+    source: https://download.nextcloud.com/server/releases/nextcloud-16.0.0.tar.bz2
+    source-checksum: sha256/4532f7028b1d9bf060f75ac4fbbde52a59ecd9c9155f3178a038d3cf3609402e
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #972 by updating Nextcloud to the latest v16 release.

---

Note that this PR gets the groundwork of upgrading out of the way and gives us something to test, but we'll continue our tradition of not upgrading everyone until the first point release (16.0.1). Please use the `16/candidate` channel if you want to upgrade to 16.0.0 now.