### PR TITLE
nextcloud: update to 16.0.5

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -158,8 +158,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-15.0.11.tar.bz2
-    source-checksum: sha256/59cdde8e7a4a15606efc246e37adf6401b0b4a60f33289be8725d675b9c2ae26
+    source: https://download.nextcloud.com/server/releases/nextcloud-16.0.5.tar.bz2
+    source-checksum: sha256/8709c64fa776fd731c8e5f1ab25d592a2e690e5e18a81601cccf363795fae551
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #972 by updating Nextcloud to the latest v16 release.