### PR TITLE
nextcloud: update to 15.0.8

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -158,8 +158,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-15.0.7.tar.bz2
-    source-checksum: sha256/3e6158951fa72010ccd50dbeac05d8df162183f7bbc62a1c6c89ed7081fa9d49
+    source: https://download.nextcloud.com/server/releases/nextcloud-15.0.8.tar.bz2
+    source-checksum: sha256/b782599fa39919ecd96d93cfb6374f4d42cd6de22a9a2d12ec11ed38a2e5f2f0
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #1003 by updating Nextcloud to the latest v15 release.