### PR TITLE
mysql: only write root password to root.ini if successfully set

### DIFF
--- a/src/mysql/bin/start_mysql
+++ b/src/mysql/bin/start_mysql
@@ -50,15 +50,14 @@ if [ $new_install = true ]; then
 		GRANT ALL PRIVILEGES ON nextcloud.* TO 'nextcloud'@'localhost' IDENTIFIED BY '$nextcloud_password';
 		SQL
 	then
+		# Now the root mysql user has a password. Save that as well.
+		echo "password=$root_password" >> "$root_option_file"
 		printf "done\n"
 	else
 		echo "Failed to initialize-- reverting..."
 		"$SNAP/support-files/mysql.server" stop
 		rm -rf "$SNAP_DATA"/mysql/*
 	fi
-
-	# Now the root mysql user has a password. Save that as well.
-	echo "password=$root_password" >> "$root_option_file"
 else
 	# Okay, this isn't a new installation. However, we recently changed
 	# the location of MySQL's socket (11.0.2snap1). Make sure the root


### PR DESCRIPTION
Ensure that the generated MySQL root password is only written to `$SNAP_DATA/mysql/root.ini` if the root password was successfully set in the database itself.

The previous behaviour was to write out the password to `root.ini` unconditionally. This sabotaged the _revert-on-failure_  logic (`rm -rf "$SNAP_DATA"/mysql/*`) as the `root.ini` file would be recreated immediately afterwards, in turn preventing subsequent attempts of initialising the database (e.g., using `snap restart` nextcloud) fail with `[ERROR] --initialize specified but the data directory has files in it. Aborting.`.