### PR TITLE
mysql: explicitly configure error log file name

### DIFF
--- a/src/mysql/my.cnf
+++ b/src/mysql/my.cnf
@@ -3,3 +3,6 @@ user=root
 max_allowed_packet=100M
 secure-file-priv=NULL
 skip-networking
+
+[mysqld_safe]
+log_error=error.log


### PR DESCRIPTION
This ensures that the error log will be stored within MySQL's data directory, which can be relied on to always exist.

Fixes #1000.

Signed-off-by: Tore Anderson <tore@fud.no>