### PR TITLE
Export/import keys

### DIFF
--- a/src/import-export/bin/export-data
+++ b/src/import-export/bin/export-data
@@ -26,7 +26,7 @@ print_usage()
 	echo "    Export Nextcloud data suitable for migrating servers."
 	echo "    By default this includes the"
         echo "    apps, database, config, keys, and data"
-	echo "    (equivalent to running $COMMAND -abcdef)."
+	echo "    (equivalent to running $COMMAND -abcde)."
 	echo ""
 	echo "Available options:"
 	echo "    -h: Display this help message"

--- a/src/import-export/bin/export-data
+++ b/src/import-export/bin/export-data
@@ -25,7 +25,7 @@ print_usage()
 	echo "    $COMMAND [OPTIONS]"
 	echo "    Export Nextcloud data suitable for migrating servers."
 	echo "    By default this includes the"
-        echo "    apps, database, config, certs, keys, and data"
+        echo "    apps, database, config, keys, and data"
 	echo "    (equivalent to running $COMMAND -abcdef)."
 	echo ""
 	echo "Available options:"
@@ -35,7 +35,6 @@ print_usage()
 	echo "    -c: Include the config"
 	echo "    -d: Include the data (can be quite large)"
 	echo "    -e: Include the encryption keys"
-	echo "    -f: Include the certificates"
 }
 
 export_apps()
@@ -123,26 +122,11 @@ export_keys()
 	fi
 }
 
-export_certs()
-{
-        backup="$1"
-        echo "Exporting certificates..."
-        if [ ! -d "$SNAP_DATA/certs" ]; then
-                echo "Certificates do not appear to be installed, skipping."
-        else
-                if ! rsync -ah --info=progress2 "$SNAP_DATA/certs/" "${backup}/certs"; then
-                        echo "Unable to export certs"
-                        exit 1
-                fi
-        fi
-}
-
 do_export_apps=false
 do_export_database=false
 do_export_config=false
 do_export_data=false
 do_export_keys=false
-do_export_certs=false
 
 # If no parameters are specified, default to exporting everything
 if [ $# -eq 0 ]; then
@@ -151,10 +135,9 @@ if [ $# -eq 0 ]; then
 	do_export_config=true
 	do_export_data=true
 	do_export_keys=false # keys already get grabbed in a full data backup
-	do_export_certs=true
 fi
 
-while getopts ":abcdefh" opt; do
+while getopts ":abcdeh" opt; do
 	case $opt in
 		a)
 			do_export_apps=true
@@ -170,9 +153,6 @@ while getopts ":abcdefh" opt; do
 			;;
 		e)
                         do_export_keys=true
-                        ;;
-		f)
-                        do_export_certs=true
                         ;;
 		h)
 			print_usage
@@ -221,10 +201,6 @@ fi
 
 if [ "$do_export_keys" = true ] && [ "$do_export_data" = false ]; then
 	export_keys "$backup"
-fi
-
-if [ "$do_export_certs" = true ]; then
-        export_certs "$backup"
 fi
 
 if [ "$do_export_data" = true ]; then

--- a/src/import-export/bin/export-data
+++ b/src/import-export/bin/export-data
@@ -23,9 +23,10 @@ print_usage()
 {
 	echo "Usage:"
 	echo "    $COMMAND [OPTIONS]"
-	echo "    Export data suitable for migrating servers. By default this"
-	echo "    includes the Nextcloud database, configuration, and data"
-	echo "    (equivalent to running $COMMAND -abcd)."
+	echo "    Export Nextcloud data suitable for migrating servers."
+	echo "    By default this includes the"
+        echo "    apps, database, config, certs, keys, and data"
+	echo "    (equivalent to running $COMMAND -abcdef)."
 	echo ""
 	echo "Available options:"
 	echo "    -h: Display this help message"
@@ -33,6 +34,8 @@ print_usage()
 	echo "    -b: Include the database"
 	echo "    -c: Include the config"
 	echo "    -d: Include the data (can be quite large)"
+	echo "    -e: Include the encryption keys"
+	echo "    -f: Include the certificates"
 }
 
 export_apps()
@@ -80,10 +83,66 @@ export_data()
 	fi
 }
 
+export_keys()
+{
+        backup="$1"
+	occ_err="/tmp/nextcloud_occ.err"
+	rsync_err="/tmp/nextcloud_rsync.err"
+	cat /dev/null > "$rsync_err"
+	
+        echo "Exporting encryption keys..."
+	encryption_status="$(nextcloud.occ encryption:status 2>$occ_err | awk 'NR==1{print $3}')"
+	if [ "$(cat $occ_err)" != "Nextcloud is in maintenance mode - no apps have been loaded" ]; then
+		# ignore the maintenance mode message but print out other errors.
+		echo "WARNING: nextcloud.occ reported an error checking the status of encryption:"
+		cat "$occ_err"
+	fi
+	if [ "$encryption_status" = "false" ]; then
+		# because these encryption directories do not exist until encryption is enabled,
+		# rsync will throw a bunch of directory not found errors
+		echo "Encryption does not appear to be enabled, skipping."
+	else
+		# back up system-wide master keys, public sharing keys, recovery keys
+		echo "Exporting system-wide keys..."
+		if ! rsync -ah --info=progress2 "$NEXTCLOUD_DATA_DIR"/files_encryption "${backup}"/keys/ 2>>"$rsync_err"; then
+			echo -e "WARNING: Unable to back up system-wide encryption keys. For details, see $rsync_err\n"
+		fi
+		# back up user keys
+		echo "Exporting user keys..."
+		# make sure the keys directory exists before rsync attempts to create subdirectories
+		# if the first backup above fails, it may not have been created
+		mkdir "${backup}/keys" 2>/dev/null
+		if ! nextcloud.occ user:list 2>"$occ_err" | awk '{print $3}' | xargs -I{} rsync -ah --info=progress2 "$NEXTCLOUD_DATA_DIR"/'{}'/files_encryption "${backup}"/keys/'{}'/ 2>>"$rsync_err"; then
+			echo -e "WARNING: One or more user keys couldn't be backed up.  If you use system-wide keys, you may ignore this. For details, see $rsync_err\n"
+		fi
+		if [ "$(cat $occ_err)" != "Nextcloud is in maintenance mode - no apps have been loaded" ]; then
+			# Ignore the maintenance mode message but print out other errors.
+			echo "WARNING: nextcloud.occ reported an error listing users:"
+			cat "$occ_err"
+		fi
+	fi
+}
+
+export_certs()
+{
+        backup="$1"
+        echo "Exporting certificates..."
+        if [ ! -d "$SNAP_DATA/certs" ]; then
+                echo "Certificates do not appear to be installed, skipping."
+        else
+                if ! rsync -ah --info=progress2 "$SNAP_DATA/certs/" "${backup}/certs"; then
+                        echo "Unable to export certs"
+                        exit 1
+                fi
+        fi
+}
+
 do_export_apps=false
 do_export_database=false
 do_export_config=false
 do_export_data=false
+do_export_keys=false
+do_export_certs=false
 
 # If no parameters are specified, default to exporting everything
 if [ $# -eq 0 ]; then
@@ -91,9 +150,11 @@ if [ $# -eq 0 ]; then
 	do_export_database=true
 	do_export_config=true
 	do_export_data=true
+	do_export_keys=false # keys already get grabbed in a full data backup
+	do_export_certs=true
 fi
 
-while getopts ":abcdh" opt; do
+while getopts ":abcdefh" opt; do
 	case $opt in
 		a)
 			do_export_apps=true
@@ -107,6 +168,12 @@ while getopts ":abcdh" opt; do
 		d)
 			do_export_data=true
 			;;
+		e)
+                        do_export_keys=true
+                        ;;
+		f)
+                        do_export_certs=true
+                        ;;
 		h)
 			print_usage
 			exit 0
@@ -150,6 +217,14 @@ fi
 
 if [ "$do_export_config" = true ]; then
 	export_config "$backup"
+fi
+
+if [ "$do_export_keys" = true ] && [ "$do_export_data" = false ]; then
+	export_keys "$backup"
+fi
+
+if [ "$do_export_certs" = true ]; then
+        export_certs "$backup"
 fi
 
 if [ "$do_export_data" = true ]; then

--- a/src/import-export/bin/import-data
+++ b/src/import-export/bin/import-data
@@ -24,7 +24,7 @@ print_usage()
 	echo "    Import data exported from another Nextcloud snap instance."
 	echo "    By default this imports the"
         echo "    apps, database, config, keys, and data"
-	echo "    (equivalent to running $COMMAND -abcdef)."
+	echo "    (equivalent to running $COMMAND -abcde)."
 	echo ""
 	echo "Available options:"
 	echo "    -h: Display this help message"

--- a/src/import-export/bin/import-data
+++ b/src/import-export/bin/import-data
@@ -23,7 +23,7 @@ print_usage()
 	echo "    $COMMAND [OPTIONS] <backup dir>"
 	echo "    Import data exported from another Nextcloud snap instance."
 	echo "    By default this imports the"
-        echo "    apps, database, config, certs, keys, and data"
+        echo "    apps, database, config, keys, and data"
 	echo "    (equivalent to running $COMMAND -abcdef)."
 	echo ""
 	echo "Available options:"
@@ -33,7 +33,6 @@ print_usage()
 	echo "    -c: Import the config"
 	echo "    -d: Import the data"
 	echo "    -e: Import the encryption keys"
-	echo "    -f: Import the certificates"
 }
 
 import_apps()
@@ -118,28 +117,11 @@ import_keys()
 	fi
 }
 
-import_certs()
-{
-	backup_dir="${1%/}"
-        certs_backup="${backup_dir}/certs"
-	if [ ! -d "$certs_backup" ]; then
-		echo "Certificates were not found in the provided backup, skipping."
-	else
-        	run_command "Clearing existing certificates" rm -rf "$SNAP_DATA/certs"
-        	echo "Importing certificates..."
-        	if ! rsync -ah --info=progress2 "$certs_backup/" "$SNAP_DATA/certs"; then
-                	echo "Unable to import certificates"
-                	exit 1
-        	fi
-	fi
-}
-
 do_import_apps=false
 do_import_database=false
 do_import_config=false
 do_import_data=false
 do_import_keys=false
-do_import_certs=false
 
 # If no parameters are specified, default to importing everything
 if [ $# -eq 1 ]; then
@@ -148,10 +130,9 @@ if [ $# -eq 1 ]; then
 	do_import_config=true
 	do_import_data=true
 	do_import_keys=false  # keys already get grabbed in a full data import
-	do_import_certs=true
 fi
 
-while getopts ":abcdefh" opt; do
+while getopts ":abcdeh" opt; do
 	case $opt in
 		a)
 			do_import_apps=true
@@ -167,9 +148,6 @@ while getopts ":abcdefh" opt; do
 			;;
 		e)
                         do_import_keys=true
-                        ;;
-		f)
-                        do_import_certs=true
                         ;;
 		h)
 			print_usage
@@ -218,10 +196,6 @@ fi
 
 if [ "$do_import_keys" = true ] && [ "$do_import_data" = false ]; then
         import_keys "$backup_dir"
-fi
-
-if [ "$do_import_certs" = true ]; then
-        import_certs "$backup_dir"
 fi
 
 if [ "$do_import_data" = true ]; then

--- a/src/import-export/bin/import-data
+++ b/src/import-export/bin/import-data
@@ -22,8 +22,9 @@ print_usage()
 	echo "Usage:"
 	echo "    $COMMAND [OPTIONS] <backup dir>"
 	echo "    Import data exported from another Nextcloud snap instance."
-	echo "    By default this imports the database, config, and data"
-	echo "    (equivalent to running $COMMAND -abcd)."
+	echo "    By default this imports the"
+        echo "    apps, database, config, certs, keys, and data"
+	echo "    (equivalent to running $COMMAND -abcdef)."
 	echo ""
 	echo "Available options:"
 	echo "    -h: Display this help message"
@@ -31,6 +32,8 @@ print_usage()
 	echo "    -b: Import the database"
 	echo "    -c: Import the config"
 	echo "    -d: Import the data"
+	echo "    -e: Import the encryption keys"
+	echo "    -f: Import the certificates"
 }
 
 import_apps()
@@ -92,10 +95,51 @@ import_data()
 	fi
 }
 
+import_keys()
+{
+	backup_dir="${1%/}"
+        keys_backup="${backup_dir}/keys"
+	occ_err="/tmp/nextcloud_occ.err"
+	if [ ! -d "$keys_backup" ]; then
+                echo "Encryption keys were not found in the provided backup, skipping."
+	else
+        	run_command "Clearing existing system-wide encryption keys" rm -rf "$NEXTCLOUD_DATA_DIR"/files_encryption
+		run_command "Clearing existing user encryption keys" nextcloud.occ user:list 2>"$occ_err" | awk '{print $3}' | xargs -I{} rm -rf "$NEXTCLOUD_DATA_DIR"/'{}'/files_encryption
+		if [ "$(cat $occ_err)" != "Nextcloud is in maintenance mode - no apps have been loaded" ]; then
+			# ignore the maintenance mode message but print out other errors.
+			echo "WARNING: nextcloud.occ reported an error checking the status of encryption:"
+			cat "$occ_err"
+		fi
+        	echo "Importing encryption keys..."
+        	if ! rsync -ah --info=progress2 "$keys_backup/" "$NEXTCLOUD_DATA_DIR"; then
+                	echo "Unable to import keys"
+                	exit 1
+        	fi
+	fi
+}
+
+import_certs()
+{
+	backup_dir="${1%/}"
+        certs_backup="${backup_dir}/certs"
+	if [ ! -d "$certs_backup" ]; then
+		echo "Certificates were not found in the provided backup, skipping."
+	else
+        	run_command "Clearing existing certificates" rm -rf "$SNAP_DATA/certs"
+        	echo "Importing certificates..."
+        	if ! rsync -ah --info=progress2 "$certs_backup/" "$SNAP_DATA/certs"; then
+                	echo "Unable to import certificates"
+                	exit 1
+        	fi
+	fi
+}
+
 do_import_apps=false
 do_import_database=false
 do_import_config=false
 do_import_data=false
+do_import_keys=false
+do_import_certs=false
 
 # If no parameters are specified, default to importing everything
 if [ $# -eq 1 ]; then
@@ -103,9 +147,11 @@ if [ $# -eq 1 ]; then
 	do_import_database=true
 	do_import_config=true
 	do_import_data=true
+	do_import_keys=false  # keys already get grabbed in a full data import
+	do_import_certs=true
 fi
 
-while getopts ":abcdh" opt; do
+while getopts ":abcdefh" opt; do
 	case $opt in
 		a)
 			do_import_apps=true
@@ -119,6 +165,12 @@ while getopts ":abcdh" opt; do
 		d)
 			do_import_data=true
 			;;
+		e)
+                        do_import_keys=true
+                        ;;
+		f)
+                        do_import_certs=true
+                        ;;
 		h)
 			print_usage
 			exit 0
@@ -162,6 +214,14 @@ fi
 
 if [ "$do_import_config" = true ]; then
 	import_config "$backup_dir"
+fi
+
+if [ "$do_import_keys" = true ] && [ "$do_import_data" = false ]; then
+        import_keys "$backup_dir"
+fi
+
+if [ "$do_import_certs" = true ]; then
+        import_certs "$backup_dir"
 fi
 
 if [ "$do_import_data" = true ]; then


### PR DESCRIPTION
Fixes #1097

**Some notes:**
I took most of this code directly from my own backup script, which I have tested and does successfully back up keys and certs.  I haven't tested these specific scripts because I have no idea how they get turned into their corresponding binaries in the snap. :woman_shrugging: I mostly just changed variable names for these scripts so it should be fine, but please someone double check my work.

It is backwards compatible with previous backups.  When importing everything from an older backup, if keys aren't found, it just skips them.

When exporting everything, if no keys are found on the system, it skips them so the rest of the backup can proceed normally.

I assume you're going to want to change the location of the temporary files I use in export_keys() and import_keys(), `/tmp/nextcloud_occ.err` and `/tmp/nextcloud_rsync.err`.  I didn't know where snap prefers to put this type of thing.


**Some questions:**
1. Is there a cleaner way to get the status of encryption and list users other than using nextcloud.occ as I do?
2. Does the built-in "run_command" need to be used instead where I execute cat or mkdir?
3. Is "run-command" going to break the piping I use in import-data line 107?


**Testing:**
To test, it should be sufficient to create text files in the appropriate directories:
`/var/snap/nextcloud/current/certs/live/test.cert`
`/var/snap/nextcloud/common/nextcloud/data/files_encryption/OC_DEFAULT_MODULE/test.key`
`/var/snap/nextcloud/common/nextcloud/data/[USER]/files_encryption/OC_DEFAULT_MODULE/test.key`