### PR TITLE
php: enable gmp

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -198,9 +198,12 @@ parts:
       - --disable-rpath
       - --enable-ftp
 
-      # Enable ldap.
+      # Enable ldap
       - --with-libdir=lib/$SNAPCRAFT_ARCH_TRIPLET
       - --with-ldap
+
+      # Enable gmp
+      - --with-gmp
     stage-packages:
       # These are only included here until the OS snap stabilizes
       - libxml2
@@ -214,6 +217,7 @@ parts:
       - libmcrypt-dev
       - libldap2-dev
       - libfreetype6-dev
+      - libgmp-dev
     prime:
      - -sbin/
      - -etc/


### PR DESCRIPTION
PHP's GMP module (and libgmp) is required for SFTP (a core feature) as well as the bookmarks app. The library is small and doesn't appear to be a security concern. This PR resolves #1112 by enabling it.