### PR TITLE
php: check file timestamps for opcache

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -246,7 +246,7 @@ parts:
     source: src/php/
     organize:
       config/*: config/php/
-    stage-packages: [mawk, libfcgi0ldbl]
+    stage-packages: [mawk]
 
   # Copy over our Nextcloud configuration files
   nextcloud-customizations:

--- a/src/common/utilities/common-utilities
+++ b/src/common/utilities/common-utilities
@@ -52,10 +52,20 @@ wait_for_command()
 
 enable_maintenance_mode()
 {
-	run_command "Enabling maintenance mode" occ -n maintenance:mode --on
+	if run_command "Enabling maintenance mode" occ -n maintenance:mode --on; then
+		# The opcache might cache changes for one second. Wait for two to be safe.
+		sleep 2
+		return 0
+	fi
+	return 1
 }
 
 disable_maintenance_mode()
 {
-	run_command "Disabling maintenance mode" occ -n maintenance:mode --off
+	if run_command "Disabling maintenance mode" occ -n maintenance:mode --off; then
+		# The opcache might cache changes for one second. Wait for two to be safe.
+		sleep 2
+		return 0
+	fi
+	return 1
 }

--- a/src/import-export/bin/import-data
+++ b/src/import-export/bin/import-data
@@ -139,7 +139,7 @@ echo "unstable, so beware if using from within scripts." >&2
 echo "" >&2
 
 # Enable maintenance mode so data can't change out from under us
-if ! enable_maintenance_mode; then
+if nextcloud_is_installed && ! enable_maintenance_mode; then
 	echo "Unable to enter maintenance mode"
 	exit 1
 fi

--- a/src/nextcloud/bin/occ
+++ b/src/nextcloud/bin/occ
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # shellcheck source=src/mysql/utilities/mysql-utilities
 . "$SNAP/utilities/mysql-utilities"
@@ -19,7 +19,3 @@ wait_for_php
 wait_for_nextcloud_to_be_configured
 
 run-php "$SNAP/htdocs/occ" "$@"
-
-# occ may have modified the config. Invalidate its cache just in case, otherwise
-# PHP won't see the changes.
-php_invalidate_opcache "$NEXTCLOUD_CONFIG_DIR/config.php"

--- a/src/php/config/php.ini
+++ b/src/php/config/php.ini
@@ -1735,12 +1735,11 @@ ldap.max_links = -1
 
 [opcache]
 zend_extension=opcache.so
-
 ; Determines if Zend OPCache is enabled
 opcache.enable=1
 
 ; Determines if Zend OPCache is enabled for the CLI version of PHP
-opcache.enable_cli=1
+;opcache.enable_cli=0
 
 ; The OPcache shared memory storage size.
 opcache.memory_consumption=128
@@ -1749,7 +1748,7 @@ opcache.memory_consumption=128
 opcache.interned_strings_buffer=8
 
 ; The maximum number of keys (scripts) in the OPcache hash table.
-; Only numbers between 200 and 100000 are allowed.
+; Only numbers between 200 and 1000000 are allowed.
 opcache.max_accelerated_files=10000
 
 ; The maximum percentage of "wasted" memory until a restart is scheduled.
@@ -1763,7 +1762,7 @@ opcache.max_accelerated_files=10000
 
 ; When disabled, you must reset the OPcache manually or restart the
 ; webserver for changes to the filesystem to take effect.
-opcache.validate_timestamps=0
+;opcache.validate_timestamps=1
 
 ; How often (in seconds) to check file timestamps for changes to the shared
 ; memory storage allocation. ("1" means validate once per second, but only
@@ -1776,9 +1775,6 @@ opcache.revalidate_freq=1
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
 opcache.save_comments=1
-
-; If enabled, a fast shutdown sequence is used for the accelerated code
-;opcache.fast_shutdown=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0
@@ -1847,9 +1843,24 @@ opcache.save_comments=1
 ; Enables or disables checksum validation when script loaded from file cache.
 ;opcache.file_cache_consistency_checks=1
 
+; Implies opcache.file_cache_only=1 for a certain process that failed to
+; reattach to the shared memory (for Windows only). Explicitly enabled file
+; cache is required.
+;opcache.file_cache_fallback=1
+
 ; Enables or disables copying of PHP code (text segment) into HUGE PAGES.
 ; This should improve performance, but requires appropriate OS configuration.
 ;opcache.huge_code_pages=1
+
+; Validate cached file permissions.
+;opcache.validate_permission=0
+
+; Prevent name collisions in chroot'ed environment.
+;opcache.validate_root=0
+
+; If specified, it produces opcode dumps for debugging different stages of
+; optimizations.
+;opcache.opt_debug_level=0
 
 [curl]
 ; A default value for the CURLOPT_CAINFO option. This is required to be an

--- a/src/php/utilities/php-utilities
+++ b/src/php/utilities/php-utilities
@@ -77,18 +77,3 @@ php_set_previous_memory_limit()
 {
 	snapctl set private.php.memory-limit="$1"
 }
-
-php_invalidate_opcache()
-{
-	tmpfile="$(mktemp --tmpdir tmp_XXXXXXXXXX.php)"
-	echo "<?php opcache_invalidate('$1'); ?>" > "$tmpfile"
-
-	export SCRIPT_FILENAME="$tmpfile"
-	export REQUEST_METHOD="GET"
-	if ! output="$(cgi-fcgi -bind -connect "$PHP_FPM_SOCKET")"; then
-		echo "Unable to invalidate opcache: $output" >&2
-	fi
-
-	# Dash doesn't support trap RETURN
-	rm -f "$tmpfile"
-}

--- a/tests/spec/maintenance_mode_spec.rb
+++ b/tests/spec/maintenance_mode_spec.rb
@@ -1,24 +1,30 @@
 feature "Maintenance mode" do
-    # Regression test for #486.
-    scenario "enable/disable" do
-        # First, verify that maintenance mode is not active
-        visit "/"
-        expect(page).not_to have_content('maintenance mode')
+	# Regression test for #486.
+	scenario "enable/disable" do
+		# First, verify that maintenance mode is not active
+		visit "/"
+		expect(page).not_to have_content('maintenance mode')
 
-        # Enable maintenance mode
-		`sudo nextcloud.occ maintenance:mode --on 2>&1`
-        expect($?.to_i).to eq 0
+		# Enable maintenance mode
+		`sudo nextcloud.occ -n maintenance:mode --on 2>&1`
+		expect($?.to_i).to eq 0
 
-        # Now verify that maintenance mode is active
-        visit "/"
-        expect(page).to have_content('maintenance mode')
+		# Maintenance mode takes one second to apply (opcache)
+		sleep 2
 
-        # Now disable maintenance mode
-        `sudo nextcloud.occ maintenance:mode --off 2>&1`
-        expect($?.to_i).to eq 0
+		# Now verify that maintenance mode is active
+		visit "/"
+		expect(page).to have_content('maintenance mode')
 
-        # Finally, verify that maintenance mode is not active again
-        visit "/"
-        expect(page).not_to have_content('maintenance mode')
+		# Now disable maintenance mode
+		`sudo nextcloud.occ -n maintenance:mode --off 2>&1`
+		expect($?.to_i).to eq 0
+
+		# Maintenance mode takes one second to apply (opcache)
+		sleep 2
+
+		# Finally, verify that maintenance mode is not active again
+		visit "/"
+		expect(page).not_to have_content('maintenance mode')
 	end
 end

--- a/tests/spec/spec_helper.rb
+++ b/tests/spec/spec_helper.rb
@@ -124,7 +124,7 @@ RSpec.configure do |config|
 
 	config.before(:suite) do
 		# Ensure the first run wizard is disabled, just in case
-		`sudo nextcloud.occ app:disable firstrunwizard`
+		`sudo nextcloud.occ -n app:disable firstrunwizard`
 	end
 
 	config.after(:each) do
@@ -133,8 +133,11 @@ RSpec.configure do |config|
 		Capybara.current_session.driver.quit
 
 		# After each test, make sure maintenance mode is reset
-		`sudo nextcloud.occ maintenance:mode --off 2>&1`
+		`sudo nextcloud.occ -n maintenance:mode --off 2>&1`
 		expect($?.to_i).to eq 0
+
+		# Maintenance mode takes a second to apply (opcache)
+		sleep 2
 
 		# Make sure any and all backups are removed
 		`sudo rm -rf /var/snap/nextcloud/common/backups`


### PR DESCRIPTION
Not checking timestamps seems like a sensible optimization given that snaps are read-only. However, this ignores the fact that apps can be installed and updated, and those are also PHP. The opcache needs to be invalidated in that case. This PR resolves #1130 by updating the PHP configuration to check file timestamps.