### PR TITLE
feat: add imagemagick

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -169,6 +169,9 @@ parts:
     # users. This does not result in an integrity check failure.
     prime:
       - -htdocs/apps/updatenotification
+    # Add imagemagick
+    stage-packages:
+      - imagemagick
 
   php:
     plugin: php


### PR DESCRIPTION
Add imagemagick to fix the warning that the php module is missing

Do I need to add the php module or just the imagemagick package?