### PR TITLE
nextcloud-fixer: update all apps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -102,7 +102,7 @@ apps:
 
 hooks:
   configure:
-    plugs: [network, network-bind]
+    plugs: [network, network-bind, removable-media]
 
 parts:
   apache:

--- a/src/nextcloud/bin/nextcloud-fixer
+++ b/src/nextcloud/bin/nextcloud-fixer
@@ -24,6 +24,13 @@ if nextcloud_is_installed; then
 	trap 'disable_maintenance_mode' EXIT
 
 	occ -n db:convert-filecache-bigint
+
+	echo "Updating all apps..."
+	if occ -n app:update --all; then
+		# app:update downloads and extracts the updates, but now we
+		# need to run upgrade to run database migrations, etc.
+		occ -n upgrade
+	fi
 else
 	wait_for_nextcloud_to_be_installed
 

--- a/src/nextcloud/bin/occ
+++ b/src/nextcloud/bin/occ
@@ -14,8 +14,8 @@ if [ "$(id -u)" -ne 0 ]; then
 	exit 1
 fi
 
-# occ can't do much before PHP FPM is up and running
 wait_for_php
+wait_for_redis
 wait_for_nextcloud_to_be_configured
 
 run-php "$SNAP/htdocs/occ" "$@"

--- a/src/nextcloud/bin/setup-nextcloud
+++ b/src/nextcloud/bin/setup-nextcloud
@@ -54,25 +54,23 @@ else
 	occ -n app:disable updatenotification
 fi
 
-# Finally, make sure nextcloud is up to date. The return code of the upgrade
-# can be used to determine the outcome:
-#    success = 0;
-#    not installed = 1;
-#    in maintenance mode = 2;
-#    already up to date = 3;
-#    invalid arguments  = 4;
-#    other failure = 5;
-echo "Making sure nextcloud is fully upgraded..."
-occ -n upgrade
-return_code=$?
-if [ $return_code -eq 1 ]; then
-	echo "Nextcloud is not yet installed-- no upgrade necessary"
-elif [ $return_code -eq 3 ]; then
-	echo "Nextcloud is fully upgraded"
-elif [ $return_code -ne 0 ]; then
-	echo "Unable to upgrade Nextcloud. Will try again."
-	# occ may have left it in maintenance mode, so turn that off
-	disable_maintenance_mode
-	sleep 10 # Delaying here so systemd doesn't throttle us
-	exit 1
+
+if nextcloud_is_installed; then
+	# Finally, make sure nextcloud is up to date. The return code of the
+	# upgrade can be used to determine the outcome:
+	#    success (or already up to date) = 0;
+	#    not installed = 1;
+	#    in maintenance mode = 2;
+	#    invalid arguments  = 4;
+	#    other failure = 5;
+	echo "Making sure nextcloud is fully upgraded..."
+	occ -n upgrade
+	return_code=$?
+	if [ $return_code -ne 0 ]; then
+		echo "Unable to upgrade Nextcloud. Will try again."
+		# occ may have left it in maintenance mode, so turn that off
+		disable_maintenance_mode
+		sleep 10 # Delaying here so systemd doesn't throttle us
+		exit 1
+	fi
 fi


### PR DESCRIPTION
Nextcloud upgrades don't update apps properly (see nextcloud/server#18673). This results in a very poor upgrade experience if a bundled app needs to update. This PR works around this issue by updating apps automatically.