### PR TITLE
nextcloud-fixer: upgrade and update apps before anything else

### DIFF
--- a/src/nextcloud/bin/nextcloud-fixer
+++ b/src/nextcloud/bin/nextcloud-fixer
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # shellcheck source=src/apache/utilities/apache-utilities
 . "$SNAP/utilities/apache-utilities"
@@ -11,11 +11,9 @@
 wait_for_apache
 
 if nextcloud_is_installed; then
-	# This command can be run without putting Nextcloud into maintenance mode
-	occ -n db:add-missing-indices
+	# Run set of fixes for an update to an existing install
+	run-parts -v --exit-on-error --regex '.*\.sh$' "$SNAP/fixes/existing-install"
 
-	# Unfortunately convert-filecache-bigint requires that Nextcloud be in maintenance
-	# mode, and can take some time.
 	if ! enable_maintenance_mode; then
 		echo "Unable to enter maintenance mode" >&2
 		sleep 10 # Give it a few seconds before bailing so systemd doesn't throttle
@@ -23,25 +21,12 @@ if nextcloud_is_installed; then
 	fi
 	trap 'disable_maintenance_mode' EXIT
 
-	occ -n db:convert-filecache-bigint
-
-	echo "Updating all apps..."
-	if occ -n app:update --all; then
-		# app:update downloads and extracts the updates, but now we
-		# need to run upgrade to run database migrations, etc.
-		occ -n upgrade
-	fi
+	# Run set of fixes for an update to an existing install that require maintenance
+	# mode
+	run-parts -v --exit-on-error --regex '.*\.sh$' "$SNAP/fixes/existing-install/maintenance"
 else
 	wait_for_nextcloud_to_be_installed
 
-	# Disable the theming app. It requires imagick (which the snap doesn't ship) and
-	# displays a warning if it's not installed. This way, the warning is only shown if
-	# someone needs and enables the theming app.
-	run_command "Disabling theming by default" occ -n app:disable theming
-
-	# Technically convert-filecache-bigint should be run under maintenance mode, but
-	# there really isn't anything to go wrong on a fresh install, and the UX of enabling
-	# maintenance mode as soon as an admin account is created is awful.
-	occ -n db:add-missing-indices
-	occ -n db:convert-filecache-bigint
+	# Run set of fixes for a fresh install
+	run-parts -v --exit-on-error --regex '.*\.sh$' "$SNAP/fixes/fresh-install"
 fi

--- a/src/nextcloud/fixes/existing-install/1_upgrade.sh
+++ b/src/nextcloud/fixes/existing-install/1_upgrade.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+# If Nextcloud just updated, it's possible that the upgrade process
+# placed app update files, but didn't run the proper migrations for
+# them. Run upgrade again to make sure
+occ -n upgrade

--- a/src/nextcloud/fixes/existing-install/2_update-apps.sh
+++ b/src/nextcloud/fixes/existing-install/2_update-apps.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+# Now explicitly update all apps, in case the upgrade step didn't do it
+if occ -n app:update --all; then
+	# app:update downloads and extracts the updates, but now we
+	# need to run database migrations, etc. so run upgrade again
+	occ -n upgrade
+fi

--- a/src/nextcloud/fixes/existing-install/3_add-missing-indices.sh
+++ b/src/nextcloud/fixes/existing-install/3_add-missing-indices.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+# This command can be run without putting Nextcloud into maintenance mode
+occ -n db:add-missing-indices

--- a/src/nextcloud/fixes/existing-install/README
+++ b/src/nextcloud/fixes/existing-install/README
@@ -1,0 +1,3 @@
+This directory contains a set of executables to be run when an existing
+instance of Nextcloud is launched (this may or may not be an upgrade).
+None of these should require maintenance mode.

--- a/src/nextcloud/fixes/existing-install/maintenance/1_convert-filecache-bigint.sh
+++ b/src/nextcloud/fixes/existing-install/maintenance/1_convert-filecache-bigint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+# Unfortunately convert-filecache-bigint requires that Nextcloud be in maintenance
+# mode, and can take some time.
+occ -n db:convert-filecache-bigint

--- a/src/nextcloud/fixes/existing-install/maintenance/README
+++ b/src/nextcloud/fixes/existing-install/maintenance/README
@@ -1,0 +1,4 @@
+This directory contains a set of executables to be run when an existing
+instance of Nextcloud is launched (this may or may not be an upgrade). All of
+these should require maintenance mode. If they don't, they should be placed in
+the parent directory.

--- a/src/nextcloud/fixes/fresh-install/1_disable-theming.sh
+++ b/src/nextcloud/fixes/fresh-install/1_disable-theming.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+
+# shellcheck source=src/common/utilities/common-utilities
+. "$SNAP/utilities/common-utilities"
+
+# Disable the theming app. It requires imagick (which the snap doesn't ship) and
+# displays a warning if it's not installed. This way, the warning is only shown if
+# someone needs and enables the theming app.
+run_command "Disabling theming by default" occ -n app:disable theming
+

--- a/src/nextcloud/fixes/fresh-install/2_add-missing-indices.sh
+++ b/src/nextcloud/fixes/fresh-install/2_add-missing-indices.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+occ -n db:add-missing-indices

--- a/src/nextcloud/fixes/fresh-install/3_convert-filecache-bigint.sh
+++ b/src/nextcloud/fixes/fresh-install/3_convert-filecache-bigint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+# Technically convert-filecache-bigint should be run under maintenance mode, but
+# there really isn't anything to go wrong on a fresh install, and the UX of enabling
+# maintenance mode as soon as an admin account is created is awful.
+occ -n db:convert-filecache-bigint

--- a/src/nextcloud/fixes/fresh-install/README
+++ b/src/nextcloud/fixes/fresh-install/README
@@ -1,0 +1,2 @@
+This directory contains a set of executables to be run when a fresh instance of
+Nextcloud is installed. None of these should require maintenance mode.


### PR DESCRIPTION
This PR fixes #1214 by making sure an upgrade and app update happens before anything else. It also refactors nextcloud-fixer to be a more easily-expanded set of fixes (hacks) by making them all shell scripts instead of lines in the same file.