### PR TITLE
nextcloud: notify admins upon update

### DIFF
--- a/src/common/utilities/common-utilities
+++ b/src/common/utilities/common-utilities
@@ -50,6 +50,16 @@ wait_for_command()
 	fi
 }
 
+get_previous_snap_version()
+{
+	snapctl get private.snap.version
+}
+
+set_previous_snap_version()
+{
+	snapctl set private.snap.version="$1"
+}
+
 enable_maintenance_mode()
 {
 	if run_command "Enabling maintenance mode" occ -n maintenance:mode --on; then

--- a/src/nextcloud/fixes/existing-install/99_notify_admins.sh
+++ b/src/nextcloud/fixes/existing-install/99_notify_admins.sh
@@ -1,0 +1,25 @@
+#!/bin/sh -e
+
+# shellcheck source=src/nextcloud/utilities/nextcloud-utilities
+. "$SNAP/utilities/nextcloud-utilities"
+# shellcheck source=src/common/utilities/common-utilities
+. "$SNAP/utilities/common-utilities"
+
+previous_version="$(get_previous_snap_version)"
+if [ "$previous_version" != "$SNAP_VERSION" ]; then
+	message="The Nextcloud snap updated itself to version $SNAP_VERSION. We"
+	message="$message are dedicated to ensuring these updates work amazingly"
+	message="$message well, but in the unlikely event something broke,"
+	message="$message remember you can revert the update with a single"
+	message="$message command:\n\n"
+	message="$message    $ sudo snap revert nextcloud\n\n"
+	message="$message Please also don't forget to log an issue:"
+	message="$message https://github.com/nextcloud/nextcloud-snap"
+
+	run_command \
+		"Notifying admins of update from ${previous_version:-unknown version} to $SNAP_VERSION" \
+		nextcloud_notify_admins \
+			"Nextcloud updated" "$(printf "%b" "$message")" || true
+
+	set_previous_snap_version "$SNAP_VERSION"
+fi

--- a/src/nextcloud/fixes/fresh-install/99_record_snap_version.sh
+++ b/src/nextcloud/fixes/fresh-install/99_record_snap_version.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+
+# shellcheck source=src/common/utilities/common-utilities
+. "$SNAP/utilities/common-utilities"
+
+# Record the snap version so we can notify when it's been updated
+set_previous_snap_version "$SNAP_VERSION"

--- a/src/nextcloud/utilities/nextcloud-utilities
+++ b/src/nextcloud/utilities/nextcloud-utilities
@@ -30,6 +30,22 @@ wait_for_nextcloud_to_be_installed()
 	wait_for_command "Waiting for Nextcloud to be installed" nextcloud_is_installed
 }
 
+# nextcloud_notify_admins <short message> <long message>
+nextcloud_notify_admins()
+{
+	if ! occ app:list --output=json | jq -e '.enabled | .notifications' > /dev/null; then
+		echo "Notifications app isn't enabled-- unable to send notification" >&2
+		return 1
+	fi
+
+	users=$(occ user:list --output=json | jq -r 'keys[]')
+	for user in $users; do
+		if occ user:info --output=json "$user" | jq -e '.groups | index("admin")' > /dev/null; then
+			occ notification:generate "$user" "$1" -l "$2"
+		fi
+	done
+}
+
 cronjob_interval()
 {
 	interval="$(snapctl get nextcloud.cron-interval)"


### PR DESCRIPTION
The main sell of the Nextcloud snap is that is updates automatically in a transactional manner. A side effect of this is that admins could completely miss the fact that an update occurred, and if the update did something they didn't expect they don't immediately know what to blame.

This PR resolves #1220 by adding the ability to notify all admins when the snap updates, making sure they know how to revert if something doesn't work properly.