### PR TITLE
mysql: update to 5.7.29

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -276,7 +276,7 @@ parts:
   mysql:
     plugin: cmake
     source: https://github.com/mysql/mysql-server.git
-    source-tag: mysql-5.7.28
+    source-tag: mysql-5.7.29
     source-depth: 1
     override-pull: |
       snapcraftctl pull


### PR DESCRIPTION
This PR is a backport of #1218, resolving #1217 for v15.