### PR TITLE
nextcloud: update to 17.0.3

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -160,8 +160,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-16.0.8.tar.bz2
-    source-checksum: sha256/252fb559814777553e57a5c486194c5e07c92e6a453e1d0bacba5f339221bf30
+    source: https://download.nextcloud.com/server/releases/nextcloud-17.0.3.tar.bz2
+    source-checksum: sha256/901d51888f47df2930a07da585b8d3cf1b70a6c9c9702971c5e2b36ed0e47444
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #1129 by updating Nextcloud to the latest v17 release.