### PR TITLE
hooks: add pre-refresh hook to update apps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -103,6 +103,8 @@ apps:
 hooks:
   configure:
     plugs: [network, network-bind, removable-media]
+  pre-refresh:
+    plugs: [network, network-bind, removable-media]
 
 parts:
   apache:

--- a/src/hooks/bin/pre-refresh
+++ b/src/hooks/bin/pre-refresh
@@ -1,0 +1,21 @@
+#!/bin/sh -e
+
+# shellcheck source=src/apache/utilities/apache-utilities
+. "$SNAP/utilities/apache-utilities"
+# shellcheck source=src/nextcloud/utilities/nextcloud-utilities
+. "$SNAP/utilities/nextcloud-utilities"
+
+# By waiting for Apache we ensure that Nextcloud is setup and fully-updated
+wait_for_apache
+
+# We're about to be refreshed. Nextcloud's update process doesn't do a good job
+# of ensuring apps are updated properly and re-enabled after the update. Let's
+# help it out a little by trying to update all apps right now, before the
+# update actually happens.
+if nextcloud_is_installed; then
+	if occ -n app:update --all; then
+		# app:update downloads and extracts the updates, but now we
+		# need to run database migrations, etc.
+		occ -n upgrade
+	fi
+fi


### PR DESCRIPTION
Nextcloud's update process doesn't do a good job of ensuring apps are updated properly and re-enabled after the update. It seems to work best if apps are already as up-to-date as they can be. This PR resolves #1243 by taking a moment to make sure all apps are up-to-date if we know we're about to be refreshed.