### PR TITLE
snap: upgrade to core18

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,72 @@
+FROM ubuntu:bionic as builder
+
+# Grab dependencies
+RUN apt update
+RUN apt dist-upgrade --yes
+RUN apt install --yes curl sudo jq squashfs-tools
+
+# Grab the core snap from the stable channel and unpack it in the proper place
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
+RUN mkdir -p /snap/core
+RUN unsquashfs -d /snap/core/current core.snap
+
+# Grab the core18 snap from the stable channel and unpack it in the proper place
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core18' | jq '.download_url' -r) --output core18.snap
+RUN mkdir -p /snap/core18
+RUN unsquashfs -d /snap/core18/current core18.snap
+
+# Grab the snapcraft snap from the stable channel and unpack it in the proper place
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=stable' | jq '.download_url' -r) --output snapcraft.snap
+RUN mkdir -p /snap/snapcraft
+RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
+
+# Grab the go snap from the stable channel and unpack it in the proper place
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/go?channel=stable' | jq '.download_url' -r) --output go.snap
+RUN mkdir -p /snap/go
+RUN unsquashfs -d /snap/go/current go.snap
+
+# Create a snapcraft runner
+RUN mkdir -p /snap/bin
+RUN echo "#!/bin/sh" > /snap/bin/snapcraft
+RUN snap_version="$(awk '/^version:/{print $2}' /snap/snapcraft/current/meta/snap.yaml)" && echo "export SNAP_VERSION=\"$snap_version\"" >> /snap/bin/snapcraft
+RUN echo 'exec "$SNAP/usr/bin/python3" "$SNAP/bin/snapcraft" "$@"' >> /snap/bin/snapcraft
+RUN chmod +x /snap/bin/snapcraft
+
+# Create a go runner
+RUN echo "#!/bin/sh" > /snap/bin/go
+RUN snap_version="$(awk '/^version:/{print $2}' /snap/go/current/meta/snap.yaml)" && echo "export SNAP_VERSION=\"$snap_version\"" >> /snap/bin/go
+RUN echo "export SNAP=\"/snap/go/current\"" >> /snap/bin/go
+RUN echo "export SNAP_NAME=\"go\"" >> /snap/bin/go
+RUN echo 'exec "$SNAP/command-go.wrapper" "$@"' >> /snap/bin/go
+RUN chmod +x /snap/bin/go
+
+# Create a gofmt runner
+RUN echo "#!/bin/sh" > /snap/bin/gofmt
+RUN snap_version="$(awk '/^version:/{print $2}' /snap/go/current/meta/snap.yaml)" && echo "export SNAP_VERSION=\"$snap_version\"" >> /snap/bin/gofmt
+RUN echo "export SNAP=\"/snap/go/current\"" >> /snap/bin/gofmt
+RUN echo "export SNAP_NAME=\"go\"" >> /snap/bin/gofmt
+RUN echo 'exec "$SNAP/command-gofmt.wrapper" "$@"' >> /snap/bin/gofmt
+RUN chmod +x /snap/bin/gofmt
+
+# Multi-stage build, only need the snaps from the builder. Copy them one at a
+# time so they can be cached.
+FROM ubuntu:bionic
+COPY --from=builder /snap/core /snap/core
+COPY --from=builder /snap/core18 /snap/core18
+COPY --from=builder /snap/snapcraft /snap/snapcraft
+COPY --from=builder /snap/go /snap/go
+COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
+COPY --from=builder /snap/bin/go /snap/bin/go
+COPY --from=builder /snap/bin/gofmt /snap/bin/gofmt
+
+# Generate locale
+RUN apt update && apt dist-upgrade --yes && apt install --yes sudo locales && locale-gen en_US.UTF-8
+
+# Set the proper environment
+ENV LANG="en_US.UTF-8"
+ENV LANGUAGE="en_US:en"
+ENV LC_ALL="en_US.UTF-8"
+ENV PATH="/snap/bin:$PATH"
+ENV SNAP="/snap/snapcraft/current"
+ENV SNAP_NAME="snapcraft"
+ENV SNAP_ARCH="amd64"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,15 @@ jobs:
      - checkout
 
      - run:
+         # Build the docker image necessary to build this snap
+         command: |
+           docker build -t nextcloud_builder .circleci/
+
+     - run:
          # Build the snap
          command: |
            docker run -v $(pwd):$(pwd) \
-                      -e SNAPCRAFT_MANAGED_HOST=yes \
-                      -t snapcore/snapcraft:stable \
+                      -t nextcloud_builder \
                       sh -c "cd $(pwd) && apt update -qq && snapcraft"
 
      - run:

--- a/snap/plugins/x-apache.py
+++ b/snap/plugins/x-apache.py
@@ -32,9 +32,7 @@ class ApachePlugin(snapcraft.BasePlugin):
         self.build_packages.extend(
             ['pkg-config', 'libapr1-dev', 'libaprutil1-dev', 'libpcre3-dev',
              'libssl-dev'])
-        self.stage_packages.extend(
-            ['libapr1', 'libaprutil1', 'libpcre3',
-             'libssl1.0.0'])
+        self.stage_packages.extend(['libapr1', 'libaprutil1'])
 
     def build(self):
         super().build()

--- a/snap/plugins/x-apache.py
+++ b/snap/plugins/x-apache.py
@@ -22,7 +22,7 @@ class ApachePlugin(snapcraft.BasePlugin):
             'default': 'event',
         }
 
-        schema['required'].append('modules')
+        schema['required'] = ['modules']
 
         return schema
 
@@ -32,6 +32,9 @@ class ApachePlugin(snapcraft.BasePlugin):
         self.build_packages.extend(
             ['pkg-config', 'libapr1-dev', 'libaprutil1-dev', 'libpcre3-dev',
              'libssl-dev'])
+        self.stage_packages.extend(
+            ['libapr1', 'libaprutil1', 'libpcre3',
+             'libssl1.0.0'])
 
     def build(self):
         super().build()

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,7 +53,7 @@ apps:
     plugs: [network, network-bind]
 
   mysqldump:
-    command: mysqldump --defaults-file=$SNAP_DATA/mysql/root.ini --lock-tables nextcloud
+    command: run-mysqldump
     plugs: [network, network-bind]
 
   # Nextcloud occ command
@@ -207,19 +207,6 @@ parts:
 
       # Enable gmp
       - --with-gmp
-    stage-packages:
-      # These are only included here until the OS snap stabilizes
-      - libxml2
-      - libpng16-16
-      # These seems to be needed for core18
-      - libcurl4
-      - libjpeg9
-      - libbz2-1.0
-      - libmcrypt4
-      - libldap-2.4-2
-      - libfreetype6
-      - libgmp10
-      - libzip4
     build-packages:
       - libxml2-dev
       - libcurl4-openssl-dev
@@ -231,6 +218,28 @@ parts:
       - libfreetype6-dev
       - libgmp-dev
       - libzip-dev
+    stage-packages:
+      - libasn1-8-heimdal
+      - libcurl4
+      - libfreetype6
+      - libgssapi3-heimdal
+      - libhcrypto4-heimdal
+      - libheimbase1-heimdal
+      - libheimntlm0-heimdal
+      - libhx509-5-heimdal
+      - libicu60
+      - libjpeg9
+      - libkrb5-26-heimdal
+      - libldap-2.4-2
+      - libnghttp2-14
+      - libpng16-16
+      - libpsl5
+      - libroken18-heimdal
+      - librtmp1
+      - libsasl2-2
+      - libwind0-heimdal
+      - libxml2
+      - libzip4
     prime:
      - -sbin/
      - -etc/
@@ -314,13 +323,12 @@ parts:
       - bison
       - libncurses5-dev
       - libaio-dev
+    stage-packages:
+      - libaio1
     stage:
       # Remove scripts that we'll be replacing with our own
       - -support-files/mysql.server
       - -COPYING
-    stage-packages:
-      # This seems to be needed for core18
-      - libaio1
     prime:
       # Remove scripts that we'll be replacing with our own
       - -support-files/mysql.server

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,13 @@ grade: stable
 confinement: strict
 base: core18
 
+architectures:
+  - build-on: amd64
+  - build-on: i386
+  - build-on: arm64
+  - build-on: armhf
+  - build-on: ppc64el
+
 apps:
   # Apache daemon
   apache:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
 
 grade: stable
 confinement: strict
+base: core18
 
 apps:
   # Apache daemon
@@ -209,11 +210,20 @@ parts:
     stage-packages:
       # These are only included here until the OS snap stabilizes
       - libxml2
-      - libpng12-0
+      - libpng16-16
+      # These seems to be needed for core18
+      - libcurl4
+      - libjpeg9
+      - libbz2-1.0
+      - libmcrypt4
+      - libldap-2.4-2
+      - libfreetype6
+      - libgmp10
+      - libzip4
     build-packages:
       - libxml2-dev
       - libcurl4-openssl-dev
-      - libpng12-dev
+      - libpng-dev
       - libjpeg9-dev
       - libbz2-dev
       - libmcrypt-dev
@@ -308,6 +318,9 @@ parts:
       # Remove scripts that we'll be replacing with our own
       - -support-files/mysql.server
       - -COPYING
+    stage-packages:
+      # This seems to be needed for core18
+      - libaio1
     prime:
       # Remove scripts that we'll be replacing with our own
       - -support-files/mysql.server
@@ -361,7 +374,7 @@ parts:
     plugin: python
     python-version: python2
     source: src/https/
-    requirements: requirements.txt
+    requirements: ["requirements.txt"]
     build-packages: [libffi-dev]
     after: [patches]
     override-build: |

--- a/src/mysql/bin/run-mysqldump
+++ b/src/mysql/bin/run-mysqldump
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+mysqldump --defaults-file="$SNAP_DATA/mysql/root.ini" --lock-tables nextcloud "$@"


### PR DESCRIPTION
@kyrofa I known this won't be merged yet (context here https://github.com/nextcloud/nextcloud-snap/issues/755#issuecomment-583815600) but I thought that I would leave my work here and (try to) maintain it, so the changes are ready when we feel confident about the upgrade.

Meanwhile, it can also be tested by someone else than me.

Also, with the OpenSSL upgrade, we get TLS 1.3 without any changes on the Apache config, so this would also resolve #1021 