### PR TITLE
Update Redis framework

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -229,13 +229,13 @@ parts:
       sbin/php-fpm: bin/php-fpm
     extensions:
       # Build the redis PHP module
-      - source: https://github.com/phpredis/phpredis/archive/3.1.4.tar.gz
-        source-checksum: sha256/656cab2eb93bd30f30701c1280707c60e5736c5420212d5d547ebe0d3f4baf71
+      - source: https://github.com/phpredis/phpredis/archive/5.1.1.tar.gz
+        source-checksum: sha256/6b054e1c944f0c415a3489cf6ac94d5423b2b506d8c36ac7a8cdd965a1c07cf9
 
   redis:
     plugin: redis
-    source: http://download.redis.io/releases/redis-4.0.13.tar.gz
-    source-checksum: sha256/17d955227966dcd68590be6139e5fe7f2d19fc4fb7334248a904ea9cdd30c1d4
+    source: http://download.redis.io/releases/redis-5.0.7.tar.gz
+    source-checksum: sha256/61db74eabf6801f057fd24b590232f2f337d422280fd19486eca03be87d3a82b
 
   redis-customizations:
     plugin: dump


### PR DESCRIPTION
This PR updates the Redis framework of the snap; that is:

- **phpredis** to 5.1.1 (from 3.1.4)
- **redis** to 5.0.7 (from 4.0.13)

@kyrofa tell me if it makes sense to update both components in the same PR or if you want separate ones.

Redis 4.x is approaching EOL, as per https://redis.io/download#other-versions:

> Redis 4.0 was released as GA in July 2017, newcomers should use Redis 5, but Redis 4 is
> currently the most production-proven release and will be updated for the next year until
> Redis 6 will be out.

I've tested this as a fresh install and everything seems fine, but I still have to test it on my own instance.

This would resolve #802