### PR TITLE
nextcloud: support notifying users with spaces in username

### DIFF
--- a/src/nextcloud/utilities/nextcloud-utilities
+++ b/src/nextcloud/utilities/nextcloud-utilities
@@ -38,8 +38,7 @@ nextcloud_notify_admins()
 		return 1
 	fi
 
-	users=$(occ user:list --output=json | jq -r 'keys[]')
-	for user in $users; do
+	occ user:list --output=json | jq -r 'keys[]' | while read -r user; do
 		if occ user:info --output=json "$user" | jq -e '.groups | index("admin")' > /dev/null; then
 			occ notification:generate "$user" "$1" -l "$2"
 		fi


### PR DESCRIPTION
Nextcloud supports creating a user with spaces in the username, which confuses the update notification. This PR fixes #1260 by updating it to support spaces.