### PR TITLE
redis: update to 5.0.8

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -234,8 +234,8 @@ parts:
 
   redis:
     plugin: redis
-    source: http://download.redis.io/releases/redis-5.0.7.tar.gz
-    source-checksum: sha256/61db74eabf6801f057fd24b590232f2f337d422280fd19486eca03be87d3a82b
+    source: http://download.redis.io/releases/redis-5.0.8.tar.gz
+    source-checksum: sha256/f3c7eac42f433326a8d981b50dba0169fdfaf46abb23fcda2f933a7552ee4ed7
 
   redis-customizations:
     plugin: dump


### PR DESCRIPTION
This PR is a backport of #1287, resolving #1286 for v16.