### PR TITLE
tests: update CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     working_directory: ~/nextcloud-snap
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-1604:202004-01
     steps:
      - checkout
 
@@ -50,7 +50,7 @@ jobs:
   test-daily-master:
     working_directory: ~/nextcloud-snap
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-1604:202004-01
     steps:
       - checkout
 
@@ -69,7 +69,7 @@ jobs:
   test-daily-v16:
     working_directory: ~/nextcloud-snap
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-1604:202004-01
     steps:
       - checkout
 
@@ -88,7 +88,7 @@ jobs:
   test-daily-v17:
     working_directory: ~/nextcloud-snap
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-1604:202004-01
     steps:
       - checkout
 
@@ -107,7 +107,7 @@ jobs:
   test-daily-v18:
     working_directory: ~/nextcloud-snap
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-1604:202004-01
     steps:
       - checkout
 

--- a/tests/spec/spec_helper.rb
+++ b/tests/spec/spec_helper.rb
@@ -9,7 +9,7 @@ require 'selenium-webdriver'
 
 Capybara.register_driver :chrome do |app|
 	options = Selenium::WebDriver::Chrome::Options.new(
-		args: %w[headless disable-gpu no-sandbox]
+		args: %w[headless disable-gpu no-sandbox ignore-certificate-errors]
 	)
 	Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end


### PR DESCRIPTION
They're apparently unwilling to fix their broken image, so we need to upgrade the one we use and hope it doesn't break other things.