### PR TITLE
nextcloud: cron should run every 5 minutes by default

### DIFF
--- a/src/nextcloud/utilities/nextcloud-utilities
+++ b/src/nextcloud/utilities/nextcloud-utilities
@@ -5,7 +5,7 @@
 
 export NEXTCLOUD_CONFIG_DIR="$SNAP_DATA/nextcloud/config"
 export NEXTCLOUD_DATA_DIR="$SNAP_COMMON/nextcloud/data"
-DEFAULT_CRONJOB_INTERVAL="15m"
+DEFAULT_CRONJOB_INTERVAL="5m"
 
 nextcloud_is_configured()
 {


### PR DESCRIPTION
This PR resolves #1345 by making 5 minutes the default cron period for new installs. Existing installs should remain unchanged, and the admin can always configure it as they see fit.