### PR TITLE
nextcloud: regenerate asset cache on startup

### DIFF
--- a/src/nextcloud/fixes/existing-install/4_regenerate-assets.sh
+++ b/src/nextcloud/fixes/existing-install/4_regenerate-assets.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+
+# This does a lot of stuff, but what we really care about is the fact that it
+# regenerates the asset caches. This is required because these caches are
+# stored alongside the data, which is unversioned. Without clearing the caches
+# on starup, a revert would try to use a newer version's CSS, for example.
+occ -n maintenance:repair


### PR DESCRIPTION
This PR resolves #1323 by regenerating the asset cache when the snap starts up. Without this, reverting the snap can result in an older Nextcloud attempting to use the assets of a newer Nextcloud, which is an experience that generally makes one sad.