### PR TITLE
Release 18.0.4snap3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v 18.0.4snap3
+  - nextcloud: regenerate asset cache on startup
+  - nextcloud: cron should run every 5 minutes by default
+
 v 18.0.4snap2
   - php: update to 7.3.18
   - mysql: update to 5.7.30

--- a/src/nextcloud/fixes/existing-install/4_regenerate-assets.sh
+++ b/src/nextcloud/fixes/existing-install/4_regenerate-assets.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+
+# This does a lot of stuff, but what we really care about is the fact that it
+# regenerates the asset caches. This is required because these caches are
+# stored alongside the data, which is unversioned. Without clearing the caches
+# on starup, a revert would try to use a newer version's CSS, for example.
+occ -n maintenance:repair

--- a/src/nextcloud/utilities/nextcloud-utilities
+++ b/src/nextcloud/utilities/nextcloud-utilities
@@ -5,7 +5,7 @@
 
 export NEXTCLOUD_CONFIG_DIR="$SNAP_DATA/nextcloud/config"
 export NEXTCLOUD_DATA_DIR="$SNAP_COMMON/nextcloud/data"
-DEFAULT_CRONJOB_INTERVAL="15m"
+DEFAULT_CRONJOB_INTERVAL="5m"
 
 nextcloud_is_configured()
 {


### PR DESCRIPTION
- nextcloud: regenerate asset cache on startup
- nextcloud: cron should run every 5 minutes by default