### PR TITLE
tests: remove v16 dailies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,25 +70,6 @@ jobs:
           # Run the tests
           command: ./.circleci/runtests.sh
 
-  test-daily-v16:
-    working_directory: ~/nextcloud-snap
-    machine:
-      image: ubuntu-1604:202004-01
-    steps:
-      - checkout
-
-      - run:
-          # Install the snap and create an admin user
-          command: |
-            sudo apt update -qq
-            sudo apt install -y snapd
-            sudo snap install nextcloud --channel=16/edge
-            sudo nextcloud.manual-install admin admin
-
-      - run:
-          # Run the tests
-          command: ./.circleci/runtests.sh
-
   test-daily-v17:
     working_directory: ~/nextcloud-snap
     machine:
@@ -142,17 +123,6 @@ workflows:
               only: develop
 
     jobs: [test-daily-master]
-
-  daily-v16:
-    triggers:
-      - schedule:
-          # 0700 UTC == 0000 PSC
-          cron: "0 7 * * *"
-          filters:
-            branches:
-              only: develop
-
-    jobs: [test-daily-v16]
 
   daily-v17:
     triggers:

--- a/.travis/cron.sh
+++ b/.travis/cron.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 latest_master_url="https://download.nextcloud.com/server/daily/latest-master.tar.bz2"
-latest_stable16_url="https://download.nextcloud.com/server/daily/latest-stable16.tar.bz2"
 latest_stable17_url="https://download.nextcloud.com/server/daily/latest-stable17.tar.bz2"
 latest_stable18_url="https://download.nextcloud.com/server/daily/latest-stable18.tar.bz2"
 
@@ -36,11 +35,6 @@ echo "Requesting build of latest master..."
 request_build \
 	"latest-master" "$latest_master_url" "master-$today" \
 	"From CI: Use Nextcloud latest master"
-
-echo "Requesting build of latest 16..."
-request_build \
-	"latest-16" "$latest_stable16_url" "16-$today" \
-	"From CI: Use Nextcloud latest 16"
 
 echo "Requesting build of latest 17..."
 request_build \


### PR DESCRIPTION
This PR resolves #1362 by disabling v16 dailies (v16 is no longer supported).