### PR TITLE
mysql: update to 5.7.30

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -279,7 +279,7 @@ parts:
   mysql:
     plugin: cmake
     source: https://github.com/mysql/mysql-server.git
-    source-tag: mysql-5.7.29
+    source-tag: mysql-5.7.30
     source-depth: 1
     override-pull: |
       snapcraftctl pull


### PR DESCRIPTION
This PR is a backport of #1329, resolving #1320 for v17.