### PR TITLE
snap: rewrite plugins to workaround snapcraft breakage

### DIFF
--- a/snap/plugins/apache.py
+++ b/snap/plugins/apache.py
@@ -1,8 +1,8 @@
 import subprocess
-import snapcraft
+import snapcraft.plugins.v1
 
 
-class ApachePlugin(snapcraft.BasePlugin):
+class ApachePlugin(snapcraft.plugins.v1.PluginV1):
 
     @classmethod
     def schema(cls):

--- a/snap/plugins/php.py
+++ b/snap/plugins/php.py
@@ -5,7 +5,7 @@ import re
 import subprocess
 
 import snapcraft
-from snapcraft.plugins import autotools
+from snapcraft.plugins.v1 import autotools
 
 logger = logging.getLogger(__name__)
 

--- a/snap/plugins/redis.py
+++ b/snap/plugins/redis.py
@@ -5,7 +5,7 @@ import re
 import subprocess
 
 import snapcraft
-from snapcraft.plugins import make
+from snapcraft.plugins.v1 import make
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Snapcraft 4.0.4 was released and broke our CI. See https://forum.snapcraft.io/t/18063 for more information.