### PR TITLE
nextcloud: update to 18.0.6

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -168,8 +168,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-18.0.4.tar.bz2
-    source-checksum: sha256/fad8e12632b352247ffc5ae181d4e414d732b9072caa0401774cfdb93a714329
+    source: https://download.nextcloud.com/server/releases/nextcloud-18.0.6.tar.bz2
+    source-checksum: sha256/3aa185f69c4e5ec7de3b3d5792003aeb4bd16a350865e447c9363019c69b15b2
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #1374 by updating Nextcloud to the latest v18 release.