### PR TITLE
mysql: ignore config files on host

### DIFF
--- a/src/mysql/bin/start_mysql
+++ b/src/mysql/bin/start_mysql
@@ -8,7 +8,7 @@ new_install=false
 
 # Make sure the database is initialized (this is safe to run if already
 # initialized)
-if mysqld --initialize-insecure --basedir="$SNAP" --datadir="$SNAP_DATA/mysql" --lc-messages-dir="$SNAP/share"; then
+if mysqld --defaults-file="$SNAP/my.cnf" --initialize-insecure --basedir="$SNAP" --datadir="$SNAP_DATA/mysql" --lc-messages-dir="$SNAP/share"; then
 	new_install=true
 fi
 

--- a/src/mysql/support-files/mysql.server
+++ b/src/mysql/support-files/mysql.server
@@ -202,7 +202,7 @@ case "$mode" in
     then
       # Give extra arguments to mysqld with the my.cnf file. This script
       # may be overwritten at next upgrade.
-      "$bindir/mysqld_safe" --datadir="$datadir" --pid-file="$mysqld_pid_file_path" --lc-messages-dir="$SNAP/share" --socket="$MYSQL_SOCKET" "$other_args" >/dev/null 2>&1 &
+      "$bindir/mysqld_safe" --defaults-file="$SNAP/my.cnf" --datadir="$datadir" --pid-file="$mysqld_pid_file_path" --lc-messages-dir="$SNAP/share" --socket="$MYSQL_SOCKET" "$other_args" >/dev/null 2>&1 &
       wait_for_pid created "$!" "$mysqld_pid_file_path"; return_value=$?
 
       # Make lock for RedHat / SuSE


### PR DESCRIPTION
Snaps are not properly confined across distributions. This has led to bad behavior in the Nextcloud snap where, if installed on a Debian system (which does not have apparmor in its kernel) that has MySQL installed, the snap will find the host's MySQL configuration files. This isn't an issue on Ubuntu or other systems where snap security is real, but sadly is [not considered a bug by snapd developers](https://bugs.launchpad.net/snapd/+bug/1819734), so we need to figure out a solution to it on our own.
    
This PR resolves #913 by explicitly not loading any config files except the one in the snap.