### PR TITLE
nextcloud: update to 19.0.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -168,8 +168,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-19.0.1.tar.bz2
-    source-checksum: sha256/4ef311e00d939915d3a9714cd3a1ad436db9157e04620e4a88c2f427e5e65b2d
+    source: https://download.nextcloud.com/server/releases/nextcloud-19.0.2.tar.bz2
+    source-checksum: sha256/8152f385fdb0645114e0043aaf07b0de046fbaf205fa6d6bf530d22db86c66a5
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #1442 by updating Nextcloud to v19.0.2.