### PR TITLE
nextcloud: update to 19.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Nextcloud server packaged as a snap. It consists of:
 
-- Nextcloud 19.0.2
+- Nextcloud 19.0.3
 - Apache 2.4
 - PHP 7.3
 - MySQL 5.7

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -168,8 +168,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-19.0.2.tar.bz2
-    source-checksum: sha256/8152f385fdb0645114e0043aaf07b0de046fbaf205fa6d6bf530d22db86c66a5
+    source: https://download.nextcloud.com/server/releases/nextcloud-19.0.3.tar.bz2
+    source-checksum: sha256/fc503985e8aa4ed795d882e35679e0e1b7670181768e7820307222d8b4658969
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #1452 by updating Nextcloud to the latest v19 release.