### PR TITLE
snapcraft.yaml: enable network monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ interface:
     $ sudo snap connect nextcloud:removable-media
 
 
+### System monitoring
+
+The System application requires a bit more access to the system than the snap
+uses by default (e.g. the ability to monitor network hardware, etc.). If you'd
+like to utilize those features, you'll need to connect the interface that
+allows that kind of access:
+
+    $ sudo snap connect nextcloud:network-observe
+
+
 ### Configuration
 
 Beyond the typical Nextcloud configuration (either by using `nextcloud.occ` or

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,7 +38,15 @@ apps:
     command: start-php-fpm
     daemon: simple
     restart-condition: always
-    plugs: [network, network-bind, removable-media]
+    plugs:
+      - network
+      - network-bind
+
+      # Optional interface for observing network in system settings
+      - network-observe
+
+      # Optional interface for accessing removable media
+      - removable-media
 
   # redis server daemon
   redis-server:


### PR DESCRIPTION
This PR resolves #1451 by adding the `network-observe` interface to the PHP-FPM service. This is not automatically connected upon install, but can be optionally connected if one would like to utilize the network monitoring functionality built into the Nextcloud system app.

To test, install/refresh the snap from the `latest/beta/pr-1455` channel, and connect the `network-observe` interface. Then visit the system app and confirm that the network information is filled out as expected.