### PR TITLE
php: include support for argon2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -223,6 +223,9 @@ parts:
 
       # Enable gmp
       - --with-gmp
+
+      # Enable argon2
+      - --with-password-argon2
     build-packages:
       - libxml2-dev
       - libcurl4-openssl-dev
@@ -234,6 +237,7 @@ parts:
       - libfreetype6-dev
       - libgmp-dev
       - libzip-dev
+      - libargon2-0-dev
     stage-packages:
       - libasn1-8-heimdal
       - libcurl4
@@ -256,6 +260,7 @@ parts:
       - libwind0-heimdal
       - libxml2
       - libzip4
+      - libargon2-0
     prime:
      - -sbin/
      - -etc/


### PR DESCRIPTION
This PR resolves #1459 by building support for argon2 into PHP.

Test this PR using the `latest/beta/pr-1461` channel:

    $ sudo snap install nextcloud --channel=latest/beta/pr-1461

Or, if you already have it installed:

    $ sudo snap refresh nextcloud --channel=latest/beta/pr-1461