### PR TITLE
php: disable output buffering

### DIFF
--- a/src/php/config/php.ini
+++ b/src/php/config/php.ini
@@ -227,7 +227,7 @@ precision = 14
 ; Development Value: 4096
 ; Production Value: 4096
 ; http://php.net/output-buffering
-output_buffering = 4096
+output_buffering = Off
 
 ; You can redirect all of the output of your scripts to a function.  For
 ; example, if you set output_handler to "mb_output_handler", character


### PR DESCRIPTION
This PR fixes #1450 by disabling output buffering in PHP. This has been a [long-standing configuration recommendation](https://docs.nextcloud.com/server/19/admin_manual/configuration_files/big_file_upload_configuration.html?highlight=output_buffering#configuring-php) that the snap never satisfied.