### PR TITLE
nextcloud: update to 20.0.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,8 +188,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-19.0.4.tar.bz2
-    source-checksum: sha256/465711715d64cbdf0465fcb4405f23b6f0947b85bbe12b6577c9e1602c63ae78
+    source: https://download.nextcloud.com/server/releases/nextcloud-20.0.1.tar.bz2
+    source-checksum: sha256/96c6b50e1e676e46cec82d8f8ff1abd5eef9dfa00580081b6c640612c3ff2efc
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess

--- a/tests/spec/change_php_memory_limit_spec.rb
+++ b/tests/spec/change_php_memory_limit_spec.rb
@@ -46,11 +46,11 @@ feature "Change PHP memory limit" do
 		fill_in "User", with: "admin"
 		fill_in "Password", with: "admin"
 		click_button "Log in"
-		expect(page).to have_content "All files"
+		expect(page).to have_content "Recommended files"
 	end
 
 	def assert_logged_in
 		visit "/"
-		expect(page).to have_content "All files"
+		expect(page).to have_content "Recommended files"
 	end
 end

--- a/tests/spec/enable_https_spec.rb
+++ b/tests/spec/enable_https_spec.rb
@@ -10,6 +10,6 @@ feature "Enabling HTTPS" do
 		fill_in "User", with: "admin"
 		fill_in "Password", with: "admin"
 		click_button "Log in"
-		expect(page).to have_content "All files"
+		expect(page).to have_content "Recommended files"
 	end
 end

--- a/tests/spec/import_export_spec.rb
+++ b/tests/spec/import_export_spec.rb
@@ -38,6 +38,6 @@ feature "Import and export data" do
 		fill_in "User", with: "admin"
 		fill_in "Password", with: "admin"
 		click_button "Log in"
-		expect(page).to have_content "All files"
+		expect(page).to have_content "Recommended files"
 	end
 end

--- a/tests/spec/login_spec.rb
+++ b/tests/spec/login_spec.rb
@@ -4,7 +4,7 @@ feature "Logging in" do
 		fill_in "User", with: "admin"
 		fill_in "Password", with: "admin"
 		click_button "Log in"
-		expect(page).to have_content "All files"
+		expect(page).to have_content "Recommended files"
 	end
 
 	scenario "Logging in with incorrect credentials" do


### PR DESCRIPTION
This PR resolves #1474 by updating Nextcloud to v20. Note that this will not be merged until at least the first point release, but this gives us a place to gather feedback.