### PR TITLE
apache,php,mysql,redis,nextcloud: add log rotation

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,23 +19,26 @@ architectures:
 apps:
   # Apache daemon
   apache:
-    command: run-httpd -k start -DFOREGROUND
-    stop-command: httpd-wrapper -k stop
+    command: bin/run-httpd -k start -DFOREGROUND
+    stop-command: bin/httpd-wrapper -k stop
+    reload-command: bin/httpd-wrapper -k graceful
     daemon: simple
     restart-condition: always
     plugs: [network, network-bind, removable-media]
 
   # MySQL daemon
   mysql:
-    command: start_mysql
+    command: bin/start_mysql
     stop-command: support-files/mysql.server stop
+    reload-command: bin/reload-mysql
     daemon: simple
     restart-condition: always
     plugs: [network, network-bind]
 
   # PHP FPM daemon
   php-fpm:
-    command: start-php-fpm
+    command: bin/start-php-fpm
+    reload-command: bin/reload-php
     daemon: simple
     restart-condition: always
     plugs:
@@ -50,71 +53,77 @@ apps:
 
   # redis server daemon
   redis-server:
-    command: start-redis-server
+    command: bin/start-redis-server
     daemon: simple
     restart-condition: always
     plugs: [network, network-bind]
 
   # mDNS daemon
   mdns-publisher:
-    command: delay-on-failure mdns-publisher nextcloud
+    command: bin/delay-on-failure mdns-publisher nextcloud
     daemon: simple
     restart-condition: always
     plugs: [network, network-bind]
 
   # MySQL client
   mysql-client:
-    command: run-mysql
+    command: bin/run-mysql
     plugs: [network, network-bind]
 
   mysqldump:
-    command: run-mysqldump
+    command: bin/run-mysqldump
     plugs: [network, network-bind]
 
   # Nextcloud occ command
   occ:
-    command: occ
+    command: bin/occ
     plugs: [network, network-bind, removable-media]
 
   enable-https:
-    command: enable-https
+    command: bin/enable-https
     plugs: [network, network-bind]
 
   disable-https:
-    command: disable-https
+    command: bin/disable-https
     plugs: [network, network-bind]
 
   renew-certs:
-    command: renew-certs
+    command: bin/renew-certs
     daemon: simple
     restart-condition: always
     plugs: [network, network-bind]
 
   nextcloud-cron:
-    command: nextcloud-cron
+    command: bin/nextcloud-cron
     daemon: simple
     restart-condition: on-failure
     plugs: [network, network-bind, removable-media]
 
   # Command for manually installing instead of visiting site to create admin.
   manual-install:
-    command: manual-install
+    command: bin/manual-install
     plugs: [network, network-bind, removable-media]
 
   import:
-    command: import-data
+    command: bin/import-data
     plugs: [network, network-bind, removable-media]
 
   export:
-    command: export-data
+    command: bin/export-data
     plugs: [network, network-bind, removable-media]
 
   # Service for automatically fixing Nextcloud indices, etc.
   nextcloud-fixer:
-    command: nextcloud-fixer
+    command: bin/nextcloud-fixer
     daemon: simple
     restart-condition: on-failure
     plugs: [network, network-bind, removable-media]
+
+  logrotate:
+    command: bin/run-logrotate
+    daemon: simple
+    restart-condition: on-failure
+    timer: 00:00 # Run once a day at midnight
 
 hooks:
   configure:
@@ -290,6 +299,7 @@ parts:
     source: src/redis/
     organize:
       config/*: config/redis/
+    after: [envsubst]
 
   # Copy over our PHP configuration file.
   php-customizations:
@@ -445,3 +455,25 @@ parts:
     organize:
       bin/: snap/hooks/
     stage-packages: [curl]
+
+  logrotate:
+    plugin: dump
+    source: src/logrotate/
+    organize:
+      config/*: config/logrotate/
+      usr/sbin/*: bin/
+    stage-packages: [logrotate]
+    stage:
+      - bin/*
+      - config/*
+      - utilities/*
+    after: [envsubst]
+
+  migrations:
+    plugin: dump
+    source: src/migrations/
+
+  envsubst:
+    plugin: nil
+    stage-packages: [gettext-base]
+    stage: [usr/bin/envsubst]

--- a/src/apache/bin/run-httpd
+++ b/src/apache/bin/run-httpd
@@ -3,8 +3,8 @@
 # shellcheck source=src/https/utilities/https-utilities
 . "$SNAP/utilities/https-utilities"
 
-mkdir -p "$SNAP_DATA/apache/logs"
-chmod 750 "$SNAP_DATA/apache/logs"
+mkdir -p "$SNAP_DATA/logs"
+chmod 750 "$SNAP_DATA/logs"
 
 # Make sure Nextcloud is installed and running
 echo "Making sure nextcloud is setup..."

--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -166,7 +166,7 @@ ProxyFCGIBackendType GENERIC
 # Default log location. If you define an error logfile for a <VirtualHost>
 # container, that host's errors will be logged there and not here.
 #
-ErrorLog "${SNAP_DATA}/apache/logs/error_log"
+ErrorLog "${SNAP_DATA}/logs/apache_errors.log"
 
 #
 # LogLevel: Control the number of messages logged to the error_log.

--- a/src/common/utilities/common-utilities
+++ b/src/common/utilities/common-utilities
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+SNAP_CURRENT="$(realpath -s "$SNAP/../current")"
+SNAP_DATA_CURRENT="$(realpath -s "$SNAP_DATA/../current")"
+export SNAP_CURRENT
+export SNAP_DATA_CURRENT
+
 stdout_is_a_terminal()
 {
 	[ -t 1 ]

--- a/src/hooks/bin/post-refresh
+++ b/src/hooks/bin/post-refresh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+run-snap-migrations

--- a/src/import-export/bin/export-data
+++ b/src/import-export/bin/export-data
@@ -49,7 +49,7 @@ export_database()
 {
 	backup="$1"
 	echo "Exporting database..."
-	if ! mysqldump --defaults-file="$SNAP_DATA/mysql/root.ini" \
+	if ! mysqldump --defaults-file="$MYSQL_ROOT_OPTION_FILE" \
 	             --lock-tables nextcloud > "${backup}/database.sql"; then
 		echo "Unable to export database"
 		exit 1

--- a/src/logrotate/bin/run-logrotate
+++ b/src/logrotate/bin/run-logrotate
@@ -1,0 +1,23 @@
+#!/bin/sh -e
+
+# shellcheck source=src/logrotate/utilities/logrotate-utilities
+. "$SNAP/utilities/logrotate-utilities"
+
+# Clean non existent log file entries from status file
+test -e "$LOGROTATE_STATUS_FILE" || touch "$LOGROTATE_STATUS_FILE"
+head -1 "$LOGROTATE_STATUS_FILE" > "${LOGROTATE_STATUS_FILE}.clean"
+sed 's/"//g' "$LOGROTATE_STATUS_FILE" | while read -r logfile date
+do
+    [ -e "$logfile" ] && echo "\"$logfile\" $date"
+done >> "${LOGROTATE_STATUS_FILE}.clean"
+mv "${LOGROTATE_STATUS_FILE}.clean" "$LOGROTATE_STATUS_FILE"
+
+# logrotate doesn't support environment variables in its configuration file,
+# so we write a converted version to disk and use that (and of course clean
+# it up afterward)
+configuration_file="$(mktemp)"
+trap 'rm -f "$configuration_file"' EXIT
+
+envsubst < "$SNAP/config/logrotate/logrotate.conf" > "$configuration_file"
+
+logrotate --verbose --state "$LOGROTATE_STATUS_FILE" "$configuration_file"

--- a/src/logrotate/config/logrotate.conf
+++ b/src/logrotate/config/logrotate.conf
@@ -1,0 +1,44 @@
+# Rotate log files every week
+weekly
+
+# Keep 4 weeks worth of logs
+rotate 4
+
+# Create new (empty) log files after rotating old ones
+create 640 root root
+
+# It's okay if the log file is missing
+missingok
+
+# Don't rotate log files that are empty
+notifempty
+
+# Compress logfiles, although wait until the next rotation in order to give
+# clients time to finish writing.
+compress
+delaycompress
+
+# Apache logs
+$SNAP_DATA_CURRENT/logs/apache_errors.log {
+	postrotate
+		snapctl restart --reload $SNAP_INSTANCE_NAME.apache
+	endscript
+}
+
+# PHP logs
+$SNAP_DATA_CURRENT/logs/php_errors.log $SNAP_DATA_CURRENT/logs/php-fpm_errors.log $SNAP_DATA_CURRENT/logs/nextcloud.log {
+	postrotate
+		snapctl restart --reload $SNAP_INSTANCE_NAME.php-fpm
+	endscript
+}
+
+# Redis logs. Note that redis reopens the log for every message, so it doesn't
+# require a postrotate
+$SNAP_DATA_CURRENT/logs/redis.log {}
+
+# MySQL logs
+$SNAP_DATA_CURRENT/logs/mysql_errors.log {
+	postrotate
+		snapctl restart --reload $SNAP_INSTANCE_NAME.mysql
+	endscript
+}

--- a/src/logrotate/utilities/logrotate-utilities
+++ b/src/logrotate/utilities/logrotate-utilities
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# shellcheck source=src/common/utilities/common-utilities
+. "$SNAP/utilities/common-utilities"
+
+export LOGROTATE_STATUS_FILE="$SNAP_DATA/logrotate/status"
+
+mkdir -p "$(dirname "$LOGROTATE_STATUS_FILE")"
+chmod 750 "$(dirname "$LOGROTATE_STATUS_FILE")"

--- a/src/migrations/bin/run-snap-migrations
+++ b/src/migrations/bin/run-snap-migrations
@@ -1,0 +1,24 @@
+#!/bin/sh -e
+
+# shellcheck source=src/common/utilities/common-utilities
+. "$SNAP/utilities/common-utilities"
+
+version_less_than()
+{
+	if [ "$1" = "$2" ]; then
+		return 1
+	fi
+
+	printf "%s\n%s" "$1" "$2" | sort -VC
+}
+
+previous_version="$(get_previous_snap_version)"
+migrations_directory="$SNAP/migrations"
+
+version_migrations="$(find "$migrations_directory" -maxdepth 1 -mindepth 1 | sort -V)"
+for directory in $version_migrations; do
+	version="$(basename "$directory")"
+	if version_less_than "$previous_version" "$version"; then
+		run-parts -v --exit-on-error --regex '.*\.sh$' "$directory"
+	fi
+done

--- a/src/migrations/migrations/19.0.3snap3/1_move-logs.sh
+++ b/src/migrations/migrations/19.0.3snap3/1_move-logs.sh
@@ -1,0 +1,36 @@
+#!/bin/sh -e
+#
+# Version 19.0.3snap3 introduced log rotation, and it also reorganized the log
+# layout. Let's move any existing logs into place so we don't lose them.
+
+mkdir -p "${SNAP_DATA}/logs"
+chmod 750 "${SNAP_DATA}/logs"
+
+apache_errors_log="$SNAP_DATA/apache/logs/error_log"
+if [ -f "$apache_errors_log" ]; then
+	mv "$apache_errors_log" "$SNAP_DATA/logs/apache_errors.log"
+fi
+
+php_errors_log="$SNAP_DATA/apache/logs/php_errors.log"
+if [ -f "$php_errors_log" ]; then
+	mv "$php_errors_log" "$SNAP_DATA/logs/php_errors.log"
+fi
+
+php_fpm_errors_log="$SNAP_DATA/php/php-fpm.log"
+if [ -f "$php_fpm_errors_log" ]; then
+	mv "$php_fpm_errors_log" "$SNAP_DATA/logs/php-fpm_errors.log"
+fi
+
+redis_log="$SNAP_DATA/redis/redis.log"
+if [ -f "$redis_log" ]; then
+	mv "$redis_log" "$SNAP_DATA/logs/redis.log"
+fi
+
+mysql_errors_log="$SNAP_DATA/mysql/error.log"
+if [ -f "$mysql_errors_log" ]; then
+	mv "$mysql_errors_log" "$SNAP_DATA/logs/mysql_errors.log"
+fi
+
+# The apache and php directories only existed to hold those logs, so we don't
+# need them anymore
+rm -rf "$SNAP_DATA/apache" "$SNAP_DATA/php"

--- a/src/mysql/bin/reload-mysql
+++ b/src/mysql/bin/reload-mysql
@@ -3,4 +3,4 @@
 # shellcheck source=src/mysql/utilities/mysql-utilities
 . "$SNAP/utilities/mysql-utilities"
 
-mysqldump --defaults-file="$MYSQL_ROOT_OPTION_FILE" --lock-tables nextcloud "$@"
+mysql_flush_logs

--- a/src/mysql/bin/run-mysql
+++ b/src/mysql/bin/run-mysql
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-mysql --defaults-file="$SNAP_DATA/mysql/root.ini" "$@"
+# shellcheck source=src/mysql/utilities/mysql-utilities
+. "$SNAP/utilities/mysql-utilities"
+
+mysql --defaults-file="$MYSQL_ROOT_OPTION_FILE" "$@"

--- a/src/mysql/bin/start_mysql
+++ b/src/mysql/bin/start_mysql
@@ -3,7 +3,9 @@
 # shellcheck source=src/mysql/utilities/mysql-utilities
 . "$SNAP/utilities/mysql-utilities"
 
-root_option_file="$SNAP_DATA/mysql/root.ini"
+mkdir -p "${SNAP_DATA}/logs"
+chmod 750 "${SNAP_DATA}/logs"
+
 new_install=false
 
 # Make sure the database is initialized (this is safe to run if already
@@ -30,12 +32,12 @@ if [ $new_install = true ]; then
 	printf "done\n"
 
 	# Save root user information
-	cat <<-EOF > "$root_option_file"
+	cat <<-EOF > "$MYSQL_ROOT_OPTION_FILE"
 		[client]
 		socket=$MYSQL_SOCKET
 		user=root
 	EOF
-	chmod 600 "$root_option_file"
+	chmod 600 "$MYSQL_ROOT_OPTION_FILE"
 
 	# Make sure we wait until MySQL is actually up before continuing
 	wait_for_mysql -f
@@ -46,7 +48,7 @@ if [ $new_install = true ]; then
 	# 3) Create the nextcloud database
 	# 4) Grant the nextcloud user privileges on the nextcloud database
 	printf "Setting up users and nextcloud database... "
-	if mysql --defaults-file="$root_option_file" <<-SQL
+	if run-mysql <<-SQL
 		ALTER USER 'root'@'localhost' IDENTIFIED BY '$root_password';
 		CREATE USER 'nextcloud'@'localhost' IDENTIFIED BY '$nextcloud_password';
 		CREATE DATABASE nextcloud;
@@ -54,7 +56,7 @@ if [ $new_install = true ]; then
 		SQL
 	then
 		# Now the root mysql user has a password. Save that as well.
-		echo "password=$root_password" >> "$root_option_file"
+		echo "password=$root_password" >> "$MYSQL_ROOT_OPTION_FILE"
 		printf "done\n"
 	else
 		echo "Failed to initialize-- undoing setup and will try again..."
@@ -66,7 +68,7 @@ else
 	# Okay, this isn't a new installation. However, we recently changed
 	# the location of MySQL's socket (11.0.2snap1). Make sure the root
 	# option file is updated to look there instead of the old location.
-	sed -ri "s|(socket\s*=\s*)/var/snap/.*mysql.sock|\1$MYSQL_SOCKET|" "$root_option_file"
+	sed -ri "s|(socket\s*=\s*)/var/snap/.*mysql.sock|\1$MYSQL_SOCKET|" "$MYSQL_ROOT_OPTION_FILE"
 fi
 
 # Wait here until mysql is running
@@ -75,7 +77,7 @@ wait_for_mysql -f
 # Check and upgrade mysql tables if necessary. This will return 0 if the upgrade
 # succeeded, in which case we need to restart mysql.
 echo "Checking/upgrading mysql tables if necessary..."
-if mysql_upgrade --defaults-file="$root_option_file"; then
+if mysql_upgrade --defaults-file="$MYSQL_ROOT_OPTION_FILE"; then
 	echo "Restarting mysql server after upgrade..."
 	"$SNAP/support-files/mysql.server" restart
 

--- a/src/mysql/my.cnf
+++ b/src/mysql/my.cnf
@@ -3,6 +3,4 @@ user=root
 max_allowed_packet=100M
 secure-file-priv=NULL
 skip-networking
-
-[mysqld_safe]
-log_error=error.log
+log_error=../logs/mysql_errors.log

--- a/src/mysql/utilities/mysql-utilities
+++ b/src/mysql/utilities/mysql-utilities
@@ -3,6 +3,7 @@
 # shellcheck source=src/common/utilities/common-utilities
 . "$SNAP/utilities/common-utilities"
 
+export MYSQL_ROOT_OPTION_FILE="$SNAP_DATA/mysql/root.ini"
 export MYSQL_PIDFILE="/tmp/pids/mysql.pid"
 export MYSQL_SOCKET="/tmp/sockets/mysql.sock"
 export NEXTCLOUD_PASSWORD_FILE="$SNAP_DATA/mysql/nextcloud_password"
@@ -54,6 +55,13 @@ mysql_pid()
 	else
 		echo "Unable to get MySQL PID as it's not yet running" >&2
 		echo ""
+	fi
+}
+
+mysql_flush_logs()
+{
+	if mysql_is_running ""; then
+		run-mysql -e 'FLUSH LOGS'
 	fi
 }
 

--- a/src/nextcloud/bin/nextcloud-cron
+++ b/src/nextcloud/bin/nextcloud-cron
@@ -16,6 +16,10 @@ while true; do
 		exit 0
 	fi
 
-	run-php "$SNAP/htdocs/cron.php"
+	# Only run cron job if Nextcloud is actually installed
+	if nextcloud_is_installed; then
+		run-php "$SNAP/htdocs/cron.php"
+	fi
+
 	sleep "$(cronjob_interval)"
 done

--- a/src/nextcloud/config/autoconfig.php
+++ b/src/nextcloud/config/autoconfig.php
@@ -2,7 +2,7 @@
 
 $snap_name = getenv('SNAP_NAME');
 
-$data_path = '/var/snap/'.$snap_name.'/current';
+$data_path = getenv('SNAP_DATA_CURRENT');
 
 $database_password = trim(file_get_contents($data_path . '/mysql/nextcloud_password'));
 

--- a/src/nextcloud/config/config.php
+++ b/src/nextcloud/config/config.php
@@ -1,6 +1,7 @@
 <?php
 
-$snap_name = getenv('SNAP_NAME');
+$snap_current = getenv('SNAP_CURRENT');
+$snap_data_current = getenv('SNAP_DATA_CURRENT');
 
 $CONFIG = array(
 /**
@@ -16,7 +17,7 @@ $CONFIG = array(
 	 * These are the default apps shipped with Nextcloud. They are read-only.
 	 */
 	array(
-		'path'=> '/snap/'.$snap_name.'/current/htdocs/apps',
+		'path'=> $snap_current.'/htdocs/apps',
 		'url' => '/apps',
 		'writable' => false,
 	),
@@ -25,7 +26,7 @@ $CONFIG = array(
 	 * This directory is writable, meant for apps installed by the user.
 	 */
 	array(
-		'path'=> '/var/snap/'.$snap_name.'/current/nextcloud/extra-apps',
+		'path'=> $snap_data_current.'/nextcloud/extra-apps',
 		'url' => '/extra-apps',
 		'writable' => true,
 	),
@@ -50,4 +51,8 @@ $CONFIG = array(
     'host' => getenv('REDIS_SOCKET'),
     'port' => 0,
 ),
+
+'log_type' => 'file',
+'logfile' => $snap_data_current.'/logs/nextcloud.log',
+'logfilemode' => 0640,
 );

--- a/src/php/bin/reload-php
+++ b/src/php/bin/reload-php
@@ -1,0 +1,6 @@
+#!#!/bin/sh
+
+# shellcheck source=src/php/utilities/php-utilities
+. "$SNAP/utilities/php-utilities"
+
+php_reload

--- a/src/php/bin/start-php-fpm
+++ b/src/php/bin/start-php-fpm
@@ -11,8 +11,8 @@
 # shellcheck source=src/nextcloud/utilities/nextcloud-utilities
 . "$SNAP/utilities/configuration-utilities"
 
-mkdir -p "${SNAP_DATA}/php"
-chmod 750 "${SNAP_DATA}/php"
+mkdir -p "$SNAP_DATA/logs"
+chmod 750 "$SNAP_DATA/logs"
 
 # We need to make sure mysql is running so we can run the migration process
 # shellcheck disable=SC2119

--- a/src/php/config/php-fpm.conf
+++ b/src/php/config/php-fpm.conf
@@ -21,7 +21,7 @@ pid = ${PHP_FPM_PIDFILE}
 ; in a local file.
 ; Note: the default prefix is /home/ubuntu/src/nextcloud-snap/parts/php/install/var
 ; Default Value: log/php-fpm.log
-error_log = ${SNAP_DATA}/php/php-fpm.log
+error_log = ${SNAP_DATA}/logs/php-fpm_errors.log
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities

--- a/src/php/config/php.ini
+++ b/src/php/config/php.ini
@@ -570,7 +570,7 @@ html_errors = On
 ;error_log = php_errors.log
 ; Log errors to syslog (Event Log on Windows).
 ;error_log = syslog
-error_log = ${SNAP_DATA}/apache/logs/php_errors.log
+error_log = ${SNAP_DATA}/logs/php_errors.log
 
 ;windows.show_crt_warning
 ; Default value: 0

--- a/src/php/utilities/php-utilities
+++ b/src/php/utilities/php-utilities
@@ -51,6 +51,13 @@ php_pid()
 	fi
 }
 
+php_reload()
+{
+	if php_is_running; then
+		kill -USR1 php_pid > /dev/null
+	fi
+}
+
 php_memory_limit()
 {
 	memory_limit="$(snapctl get php.memory-limit)"

--- a/src/redis/bin/start-redis-server
+++ b/src/redis/bin/start-redis-server
@@ -3,10 +3,10 @@
 # shellcheck source=src/redis/utilities/redis-utilities
 . "$SNAP/utilities/redis-utilities"
 
-mkdir -p "${SNAP_DATA}/redis"
-chmod 750 "${SNAP_DATA}/redis"
+mkdir -p "${SNAP_DATA}/logs"
+chmod 750 "${SNAP_DATA}/logs"
 
 # redis doesn't support environment variables in its config files. Thankfully
 # it supports reading the config file from stdin though, so we'll rewrite the
 # config file on the fly and pipe it in.
-sed -e "s|\${SNAP_DATA}|$SNAP_DATA|;s|\${REDIS_PIDFILE}|$REDIS_PIDFILE|;s|\${REDIS_SOCKET}|$REDIS_SOCKET|" "$SNAP/config/redis/redis.conf" | redis-server -
+envsubst < "$SNAP/config/redis/redis.conf" | redis-server -

--- a/src/redis/config/redis.conf
+++ b/src/redis/config/redis.conf
@@ -160,7 +160,7 @@ loglevel notice
 # Specify the log file name. Also the empty string can be used to force
 # Redis to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
-logfile ${SNAP_DATA}/redis/redis.log
+logfile ${SNAP_DATA}/logs/redis.log
 
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.

--- a/src/redis/utilities/redis-utilities
+++ b/src/redis/utilities/redis-utilities
@@ -8,8 +8,10 @@ export REDIS_SOCKET="/tmp/sockets/redis.sock"
 
 mkdir -p "$(dirname "$REDIS_PIDFILE")"
 mkdir -p "$(dirname "$REDIS_SOCKET")"
+mkdir -p "$SNAP_DATA/redis"
 chmod 750 "$(dirname "$REDIS_PIDFILE")"
 chmod 750 "$(dirname "$REDIS_SOCKET")"
+chmod 750 "$SNAP_DATA/redis"
 
 redis_is_running()
 {


### PR DESCRIPTION
This PR fixes #1476 by adding logrotate to the snap, and setting up all service logs to be rotated. It also reorganizes the existing logs to make this more straight-forward.