### PR TITLE
mysql: ensure mysqld responds before considering it up

### DIFF
--- a/src/mysql/bin/start_mysql
+++ b/src/mysql/bin/start_mysql
@@ -37,6 +37,9 @@ if [ $new_install = true ]; then
 	EOF
 	chmod 600 "$root_option_file"
 
+	# Make sure we wait until MySQL is actually up before continuing
+	wait_for_mysql -f
+
 	# Now set everything up in one step:
 	# 1) Set the root user's password
 	# 2) Create the nextcloud user
@@ -54,9 +57,10 @@ if [ $new_install = true ]; then
 		echo "password=$root_password" >> "$root_option_file"
 		printf "done\n"
 	else
-		echo "Failed to initialize-- reverting..."
+		echo "Failed to initialize-- undoing setup and will try again..."
 		"$SNAP/support-files/mysql.server" stop
 		rm -rf "$SNAP_DATA"/mysql/*
+		exit 1
 	fi
 else
 	# Okay, this isn't a new installation. However, we recently changed

--- a/src/mysql/utilities/mysql-utilities
+++ b/src/mysql/utilities/mysql-utilities
@@ -19,7 +19,10 @@ mysql_is_running()
 {
 	# Arguments:
 	#  -f: Force the check, i.e. ignore if it's currently in setup
-	[ -f "$MYSQL_PIDFILE" ] && [ -S "$MYSQL_SOCKET" ] && (! mysql_setup_running || [ "$1" = "-f" ])
+	[ -f "$MYSQL_PIDFILE" ] && \
+		[ -S "$MYSQL_SOCKET" ] && \
+		run-mysql -e 'SHOW DATABASES' > /dev/null 2>&1 && \
+		(! mysql_setup_running || [ "$1" = "-f" ])
 }
 
 wait_for_mysql()


### PR DESCRIPTION
There are a number of examples where the mysql service in the snap fails to fire up because, despite the mysql socket and pid being available, mysqld doesn't seem to respond properly. This PR fixes #1478 by adding a simple command to the status check to ensure there's no race condition.

Builds of this PR for all architectures are available in the `beta/pr-1481` channel. To test it, run:

    $ sudo snap install nextcloud --channel=latest/beta/pr-1481

Or, if you already have it installed:

    $ sudo snap refresh nextcloud --channel=latest/beta/pr-1481