### PR TITLE
migrations: sanity check nextcloud version before upgrade

### DIFF
--- a/src/migrations/bin/run-snap-migrations
+++ b/src/migrations/bin/run-snap-migrations
@@ -12,10 +12,48 @@ version_less_than()
 	printf "%s\n%s" "$1" "$2" | sort -VC
 }
 
-previous_version="$(get_previous_snap_version)"
-migrations_directory="$SNAP/migrations"
+major_version()
+{
+	echo "$1" | sed -r 's/([0-9]+)\..*/\1/'
+}
 
-version_migrations="$(find "$migrations_directory" -maxdepth 1 -mindepth 1 | sort -V)"
+# Before we do any migrations, Nextcloud is very strict about what makes for a
+# valid upgrade:
+#
+# 1. A minor version upgrade (i.e. with the same major version).
+# 2. A single major version upgrade (e.g. 18 to 19, not 18 to 20).
+# 3. No downgrades are supported.
+#
+# Enforce those rules so folks don't end up needing to revert.
+
+previous_version="$(get_previous_snap_version)"
+current_version="$SNAP_VERSION"
+
+# Before we can compare versions, we must first confirm we HAVE them both
+if [ -z "$previous_version" ] || [ -z "$current_version" ]; then
+	exit 0
+fi
+
+# First of all, let's make sure that the new version is actually newer than the
+# previous one. If it's not, we already know there are problems.
+if version_less_than "$current_version" "$previous_version"; then
+	echo "Nextcloud doesn't support downgrades, but you can revert. See 'snap revert -h' for details." >&2
+	exit 1
+fi
+
+previous_major_version="$(major_version "$previous_version")"
+current_major_version="$(major_version "$current_version")"
+
+# Now make sure the major version jump is less than or equal to 1
+if [ "$((current_major_version-previous_major_version))" -gt "1" ]; then
+	next_major_version="$((previous_major_version+1))"
+	echo "Nextcloud doesn't support skipping major versions, you must upgrade to Nextcloud $next_major_version first. Try 'sudo snap refresh nextcloud --channel=$next_major_version'" >&2
+	exit 1
+fi
+
+# Now run the version-specific migrations
+migrations_directory="$SNAP/migrations"
+version_migrations="$(find "$migrations_directory" -maxdepth 1 -mindepth 1 -type d | sort -V)"
 for directory in $version_migrations; do
 	version="$(basename "$directory")"
 	if version_less_than "$previous_version" "$version"; then


### PR DESCRIPTION
Nextcloud is strict about what makes for a valid upgrade. Minor version jumps are okay (i.e. within the same major version). Single major version jumps are also okay, but not more than one (e.g. 18 to 19 is okay, but not 18 to 20). Downgrades are never okay.
    
This PR resolves #1393 by adding a check to the migration runner (which is run by the post-refresh hook) to ensure that the snap doesn't allow such a refresh to occur, which should relieve a lot of potential stress and reverts.