### PR TITLE
hooks: check that apps.nextcloud.com is up before refreshing

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -436,3 +436,4 @@ parts:
     source: src/hooks/
     organize:
       bin/: snap/hooks/
+    stage-packages: [curl]

--- a/src/hooks/bin/pre-refresh
+++ b/src/hooks/bin/pre-refresh
@@ -13,6 +13,14 @@ wait_for_apache
 # help it out a little by trying to update all apps right now, before the
 # update actually happens.
 if nextcloud_is_installed; then
+	# Before attempting an update, or otherwise allowing the refresh to
+	# continue, ensure the website that hosts Nextcloud apps is up. If
+	# it's down, app updates won't work, and the refresh can go sideways.
+	if ! curl -Is --max-time 10 https://apps.nextcloud.com > /dev/null 2>&1; then
+		echo "Unable to refresh: apps.nextcloud.com seems to be down, please try again later" >&2
+		exit 1
+	fi
+
 	if occ -n app:update --all; then
 		# app:update downloads and extracts the updates, but now we
 		# need to run database migrations, etc.


### PR DESCRIPTION
Trying to update apps or upgrade Nextcloud while apps.nextcloud.com is down is a recipe for problems. This PR resolves #1485 by canceling a refresh if it seems to be down.