### PR TITLE
nextcloud: update to 19.0.4

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,8 +188,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-19.0.3.tar.bz2
-    source-checksum: sha256/fc503985e8aa4ed795d882e35679e0e1b7670181768e7820307222d8b4658969
+    source: https://download.nextcloud.com/server/releases/nextcloud-19.0.4.tar.bz2
+    source-checksum: sha256/465711715d64cbdf0465fcb4405f23b6f0947b85bbe12b6577c9e1602c63ae78
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #1487 by updating Nextcloud to the latest v19 release.