### PR TITLE
mysql: update to 5.7.31

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -305,7 +305,7 @@ parts:
   mysql:
     plugin: cmake
     source: https://github.com/mysql/mysql-server.git
-    source-tag: mysql-5.7.30
+    source-tag: mysql-5.7.31
     source-depth: 1
     override-pull: |
       snapcraftctl pull


### PR DESCRIPTION
This PR is a backport of #1409, resolving #1404 for v18.