### PR TITLE
nextcloud: update to 18.0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Nextcloud server packaged as a snap. It consists of:
 
-- Nextcloud 18.0.6
+- Nextcloud 18.0.10
 - Apache 2.4
 - PHP 7.3
 - MySQL 5.7

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -168,8 +168,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-18.0.6.tar.bz2
-    source-checksum: sha256/3aa185f69c4e5ec7de3b3d5792003aeb4bd16a350865e447c9363019c69b15b2
+    source: https://download.nextcloud.com/server/releases/nextcloud-18.0.10.tar.bz2
+    source-checksum: sha256/26c7bfd681b726dfa776994ee9d767ef1eddd14a261d01274a196a336cab694f
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #1496 by updating Nextcloud to the latest v18 release.