### PR TITLE
logrotate: remove status file if it seems corrupted

### DIFF
--- a/src/logrotate/bin/run-logrotate
+++ b/src/logrotate/bin/run-logrotate
@@ -20,4 +20,9 @@ trap 'rm -f "$configuration_file"' EXIT
 
 envsubst < "$SNAP/config/logrotate/logrotate.conf" > "$configuration_file"
 
-logrotate --verbose --state "$LOGROTATE_STATUS_FILE" "$configuration_file"
+# If logrotate fails, it could be due to corruption in the status file. Try
+# removing it so we start with a clean slate next time around.
+if ! logrotate --verbose --state "$LOGROTATE_STATUS_FILE" "$configuration_file"; then
+    rm -f "$LOGROTATE_STATUS_FILE"
+    exit 1
+fi


### PR DESCRIPTION
This PR fixes #1508 by removing the status file if logrotate exits non-zero. This means we may miss a rotation, but that seems a small price to pay for handling this error.

To test this PR, install the snap from the `latest/beta/pr-1513` channel:

    $ sudo snap install nextcloud --channel=latest/beta/pr-1513

Or, if you already have it installed:

    $ sudo snap refresh nextcloud --channel=latest/beta/pr-1513