### PR TITLE
Release 19.0.4snap2

### DIFF
--- a/.travis/cron.sh
+++ b/.travis/cron.sh
@@ -3,6 +3,7 @@
 latest_master_url="https://download.nextcloud.com/server/daily/latest-master.tar.bz2"
 latest_stable18_url="https://download.nextcloud.com/server/daily/latest-stable18.tar.bz2"
 latest_stable19_url="https://download.nextcloud.com/server/daily/latest-stable19.tar.bz2"
+latest_stable20_url="https://download.nextcloud.com/server/daily/latest-stable20.tar.bz2"
 
 rewrite_snapcraft_yaml()
 {
@@ -45,3 +46,8 @@ echo "Requesting build of latest 19..."
 request_build \
 	"latest-19" "$latest_stable19_url" "19-$today" \
 	"From CI: Use Nextcloud latest 19"
+
+echo "Requesting build of latest 20..."
+request_build \
+	"latest-20" "$latest_stable20_url" "20-$today" \
+	"From CI: Use Nextcloud latest 20"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+v 19.0.4snap2
+  - logrotate: skip first line of status file when cleaning
+  - logrotate: remove status file if it seems corrupted
+  - mysql: update to 5.7.32
+  - migrations: support daily versions
+
 v 19.0.4snap1
   - apache: enable access log
   - apache,php,mysql,redis,nextcloud: add log rotation

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -345,7 +345,7 @@ parts:
   mysql:
     plugin: cmake
     source: https://github.com/mysql/mysql-server.git
-    source-tag: mysql-5.7.31
+    source-tag: mysql-5.7.32
     source-depth: 1
     override-pull: |
       snapcraftctl pull

--- a/src/logrotate/bin/run-logrotate
+++ b/src/logrotate/bin/run-logrotate
@@ -6,7 +6,7 @@
 # Clean non existent log file entries from status file
 test -e "$LOGROTATE_STATUS_FILE" || touch "$LOGROTATE_STATUS_FILE"
 head -1 "$LOGROTATE_STATUS_FILE" > "${LOGROTATE_STATUS_FILE}.clean"
-sed 's/"//g' "$LOGROTATE_STATUS_FILE" | while read -r logfile date
+sed '1d; s/"//g' "$LOGROTATE_STATUS_FILE" | while read -r logfile date
 do
     [ -e "$logfile" ] && echo "\"$logfile\" $date"
 done >> "${LOGROTATE_STATUS_FILE}.clean"

--- a/src/logrotate/bin/run-logrotate
+++ b/src/logrotate/bin/run-logrotate
@@ -20,4 +20,9 @@ trap 'rm -f "$configuration_file"' EXIT
 
 envsubst < "$SNAP/config/logrotate/logrotate.conf" > "$configuration_file"
 
-logrotate --verbose --state "$LOGROTATE_STATUS_FILE" "$configuration_file"
+# If logrotate fails, it could be due to corruption in the status file. Try
+# removing it so we start with a clean slate next time around.
+if ! logrotate --verbose --state "$LOGROTATE_STATUS_FILE" "$configuration_file"; then
+    rm -f "$LOGROTATE_STATUS_FILE"
+    exit 1
+fi

--- a/src/migrations/bin/run-snap-migrations
+++ b/src/migrations/bin/run-snap-migrations
@@ -14,7 +14,12 @@ version_less_than()
 
 major_version()
 {
-	echo "$1" | sed -r 's/([0-9]+)\..*/\1/'
+	echo "$1" | sed -r 's/([0-9]+)[.-].*/\1/'
+}
+
+is_integer()
+{
+	expr "$1" : '^[0-9]\+$' > /dev/null
 }
 
 # Before we do any migrations, Nextcloud is very strict about what makes for a
@@ -41,14 +46,20 @@ if version_less_than "$current_version" "$previous_version"; then
 	exit 1
 fi
 
+# Now attempt to extract the major version
 previous_major_version="$(major_version "$previous_version")"
 current_major_version="$(major_version "$current_version")"
 
-# Now make sure the major version jump is less than or equal to 1
-if [ "$((current_major_version-previous_major_version))" -gt "1" ]; then
-	next_major_version="$((previous_major_version+1))"
-	echo "Nextcloud doesn't support skipping major versions, you must upgrade to Nextcloud $next_major_version first. Try 'sudo snap refresh nextcloud --channel=$next_major_version'" >&2
-	exit 1
+# Verify that what we got was actually integers (not all versions work this
+# way, e.g. the daily builds). This isn't an error, we just can't reliably
+# check this without numbers.
+if is_integer "$previous_major_version" && is_integer "$current_major_version"; then
+	# Now make sure the major version jump is less than or equal to 1
+	if [ "$((current_major_version-previous_major_version))" -gt "1" ]; then
+		next_major_version="$((previous_major_version+1))"
+		echo "Nextcloud doesn't support skipping major versions, you must upgrade to Nextcloud $next_major_version first. Try 'sudo snap refresh nextcloud --channel=$next_major_version'" >&2
+		exit 1
+	fi
 fi
 
 # Now run the version-specific migrations

--- a/src/mysql/bin/reload-mysql
+++ b/src/mysql/bin/reload-mysql
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # shellcheck source=src/mysql/utilities/mysql-utilities
 . "$SNAP/utilities/mysql-utilities"

--- a/src/mysql/bin/run-mysql
+++ b/src/mysql/bin/run-mysql
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # shellcheck source=src/mysql/utilities/mysql-utilities
 . "$SNAP/utilities/mysql-utilities"

--- a/src/mysql/bin/run-mysqldump
+++ b/src/mysql/bin/run-mysqldump
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # shellcheck source=src/mysql/utilities/mysql-utilities
 . "$SNAP/utilities/mysql-utilities"

--- a/src/mysql/bin/start_mysql
+++ b/src/mysql/bin/start_mysql
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # shellcheck source=src/mysql/utilities/mysql-utilities
 . "$SNAP/utilities/mysql-utilities"


### PR DESCRIPTION
- logrotate: skip first line of status file when cleaning
- logrotate: remove status file if it seems corrupted
- mysql: update to 5.7.32
- migrations: support daily versions