### PR TITLE
nextcloud: workaround invalid json from occ

### DIFF
--- a/src/nextcloud/utilities/nextcloud-utilities
+++ b/src/nextcloud/utilities/nextcloud-utilities
@@ -33,13 +33,13 @@ wait_for_nextcloud_to_be_installed()
 # nextcloud_notify_admins <short message> <long message>
 nextcloud_notify_admins()
 {
-	if ! occ app:list --output=json | jq -e '.enabled | .notifications' > /dev/null; then
+	if ! occ app:list --output=json | jq -eR 'fromjson? | .enabled | .notifications' > /dev/null; then
 		echo "Notifications app isn't enabled-- unable to send notification" >&2
 		return 1
 	fi
 
-	occ user:list --output=json | jq -r 'keys[]' | while read -r user; do
-		if occ user:info --output=json "$user" | jq -e '.groups | index("admin")' > /dev/null; then
+	occ user:list --output=json | jq -rR 'fromjson? | keys[]' | while read -r user; do
+		if occ user:info --output=json "$user" | jq -eR 'fromjson? | .groups | index("admin")' > /dev/null; then
 			occ notification:generate "$user" "$1" -l "$2"
 		fi
 	done


### PR DESCRIPTION
There are situations where `occ --output=json` produces invalid json (see #1504 and https://github.com/nextcloud/server/issues/23596). Work around these issues using jq.