### PR TITLE
tests: enable daily v20 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,24 @@ jobs:
           # Run the tests
           command: ./.circleci/runtests.sh
 
+  test-daily-v20:
+    working_directory: ~/nextcloud-snap
+    machine:
+      image: ubuntu-1604:202004-01
+    steps:
+      - checkout
+
+      - run:
+          # Install the snap and create an admin user
+          command: |
+            sudo apt update -qq
+            sudo apt install -y snapd
+            sudo snap install nextcloud --channel=20/edge
+
+      - run:
+          # Run the tests
+          command: ./.circleci/runtests.sh
+
 workflows:
   version: 2
   commit:
@@ -141,3 +159,14 @@ workflows:
               only: develop
 
     jobs: [test-daily-v19]
+
+  daily-v20:
+    triggers:
+      - schedule:
+          # 0700 UTC == 0000 PSC
+          cron: "0 7 * * *"
+          filters:
+            branches:
+              only: develop
+
+    jobs: [test-daily-v20]

--- a/tests/spec/change_php_memory_limit_spec.rb
+++ b/tests/spec/change_php_memory_limit_spec.rb
@@ -46,11 +46,11 @@ feature "Change PHP memory limit" do
 		fill_in "User", with: "admin"
 		fill_in "Password", with: "admin"
 		click_button "Log in"
-		expect(page).to have_content "Recommended files"
+		expect(page).to have_content /(Recommended|All) files/
 	end
 
 	def assert_logged_in
 		visit "/"
-		expect(page).to have_content "Recommended files"
+		expect(page).to have_content /(Recommended|All) files/
 	end
 end

--- a/tests/spec/enable_https_spec.rb
+++ b/tests/spec/enable_https_spec.rb
@@ -10,6 +10,6 @@ feature "Enabling HTTPS" do
 		fill_in "User", with: "admin"
 		fill_in "Password", with: "admin"
 		click_button "Log in"
-		expect(page).to have_content "Recommended files"
+		expect(page).to have_content /(Recommended|All) files/
 	end
 end

--- a/tests/spec/import_export_spec.rb
+++ b/tests/spec/import_export_spec.rb
@@ -38,6 +38,6 @@ feature "Import and export data" do
 		fill_in "User", with: "admin"
 		fill_in "Password", with: "admin"
 		click_button "Log in"
-		expect(page).to have_content "Recommended files"
+		expect(page).to have_content /(Recommended|All) files/
 	end
 end

--- a/tests/spec/login_spec.rb
+++ b/tests/spec/login_spec.rb
@@ -4,7 +4,7 @@ feature "Logging in" do
 		fill_in "User", with: "admin"
 		fill_in "Password", with: "admin"
 		click_button "Log in"
-		expect(page).to have_content "Recommended files"
+		expect(page).to have_content /(Recommended|All) files/
 	end
 
 	scenario "Logging in with incorrect credentials" do


### PR DESCRIPTION
This PR resolves #1519 by updating tests to pass for both v20 and earlier major versions, and enabling daily tests against v20.