### PR TITLE
nextcloud: Update to 20.0.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,8 +188,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-20.0.1.tar.bz2
-    source-checksum: sha256/96c6b50e1e676e46cec82d8f8ff1abd5eef9dfa00580081b6c640612c3ff2efc
+    source: https://download.nextcloud.com/server/releases/nextcloud-20.0.2.tar.bz2
+    source-checksum: sha256/be84c2ac7fba066ddc0637a4672b39628bbbd200dad8c00a0437a4765007dd21
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #1551 by updating Nextcloud to the latest v20 release.