### PR TITLE
nextcloud: update to 18.0.11

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -168,8 +168,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-18.0.10.tar.bz2
-    source-checksum: sha256/26c7bfd681b726dfa776994ee9d767ef1eddd14a261d01274a196a336cab694f
+    source: https://download.nextcloud.com/server/releases/nextcloud-18.0.11.tar.bz2
+    source-checksum: sha256/647b6e085600bbac3b7523437e6846e39a516192d8a27b873a3feba090e723e6
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #1561 by updating Nextcloud to the latest v18 release.