### PR TITLE
nextcloud-fixer: run db:add-missing-primary-keys

### DIFF
--- a/src/nextcloud/fixes/existing-install/6_add-missing-primary-keys.sh
+++ b/src/nextcloud/fixes/existing-install/6_add-missing-primary-keys.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+# This command can be run without putting Nextcloud into maintenance mode
+occ -n db:add-missing-primary-keys


### PR DESCRIPTION
This PR resolves #1565 by running `occ db:add-missing-primary-keys` on behalf of the user on existing installs.