### PR TITLE
Release 20.0.2snap2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v 20.0.2snap2
+  - nextcloud-fixer: run db:add-missing-primary-keys
+
 v 20.0.2snap1
   - php: update to 7.4.13
   - nextcloud: update to 20.0.2

--- a/src/nextcloud/fixes/existing-install/6_add-missing-primary-keys.sh
+++ b/src/nextcloud/fixes/existing-install/6_add-missing-primary-keys.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+# This command can be run without putting Nextcloud into maintenance mode
+occ -n db:add-missing-primary-keys


### PR DESCRIPTION
- nextcloud-fixer: run db:add-missing-primary-keys