### PR TITLE
mysql: use READ-COMMITTED instead of REPEATABLE-READ

### DIFF
--- a/src/mysql/my.cnf
+++ b/src/mysql/my.cnf
@@ -3,4 +3,5 @@ user=root
 max_allowed_packet=100M
 secure-file-priv=NULL
 skip-networking
+transaction_isolation=READ-COMMITTED
 log_error=../logs/mysql_errors.log


### PR DESCRIPTION
This PR resolves #1571 by updating the MySQL transaction isolation to the value recommended by Nextcloud. It might improve MySQL performance in the snap.

In order to test this PR, install the snap from the `latest/beta/pr-1583` channel:

    $ sudo snap install nextcloud --channel=latest/beta/pr-1583

Or, if you already have it installed:

    $ sudo snap refresh nextcloud --channel=latest/beta/pr-1583