### PR TITLE
Release 20.0.4snap1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v 20.0.4snap1
+  - nextcloud: update to 20.0.4
+  - mysql: use READ-COMMITTED instead of REPEATABLE-READ
+
 v 20.0.3snap1
   - nextcloud: update to 20.0.3
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Nextcloud server packaged as a snap. It consists of:
 
-- Nextcloud 20.0.3
+- Nextcloud 20.0.4
 - Apache 2.4
 - PHP 7.3
 - MySQL 5.7

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,8 +188,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-20.0.3.tar.bz2
-    source-checksum: sha256/e0f64504d338f64d3c677357f0012cf8b0ed0dc42ec08f958b6dc4ff70edf175
+    source: https://download.nextcloud.com/server/releases/nextcloud-20.0.4.tar.bz2
+    source-checksum: sha256/269f1622e326f5d11e387d3861aad4e2b0e79334ae97eed5a7b3352ba7661420
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess

--- a/src/mysql/my.cnf
+++ b/src/mysql/my.cnf
@@ -3,4 +3,5 @@ user=root
 max_allowed_packet=100M
 secure-file-priv=NULL
 skip-networking
+transaction_isolation=READ-COMMITTED
 log_error=../logs/mysql_errors.log


### PR DESCRIPTION
- nextcloud: update to 20.0.4
- mysql: use READ-COMMITTED instead of REPEATABLE-READ