### PR TITLE
Correctly obtain the PHP-FPM pid before sending a signal

### DIFF
--- a/src/php/utilities/php-utilities
+++ b/src/php/utilities/php-utilities
@@ -54,7 +54,8 @@ php_pid()
 php_reload()
 {
 	if php_is_running; then
-		kill -USR1 php_pid > /dev/null
+		pid="$(php_pid)"
+		kill -USR1 "$pid" > /dev/null
 	fi
 }
 


### PR DESCRIPTION
On my system, when a reload is attempted it fails with the following log entries:

```
Feb 28 00:00:16 yami systemd[1]: Reloading Service for snap application nextcloud.php-fpm.
Feb 28 00:00:16 yami nextcloud.php-fpm[384399]: /snap/nextcloud/26119/bin/reload-php: 57: kill: Illegal number: php_pid
Feb 28 00:00:16 yami systemd[1]: snap.nextcloud.php-fpm.service: Control process exited, code=exited, status=2/INVALIDARGUMENT
Feb 28 00:00:16 yami systemd[1]: Reload failed for Service for snap application nextcloud.php-fpm.
Feb 28 00:00:16 yami systemd[1]: Cannot find unit for notify message of PID 384398, ignoring.
Feb 28 00:00:16 yami snapd[802]: taskrunner.go:271: [change 92 "reload-or-restart of [nextcloud.php-fpm]" task] failed: exit status 1
Feb 28 00:00:17 yami nextcloud.logrotate[384392]: error: error running snapctl: cannot perform the following tasks:
Feb 28 00:00:17 yami nextcloud.logrotate[384392]: - reload-or-restart of [nextcloud.php-fpm] (# systemctl reload-or-restart snap.nextcloud.php-fpm.service
Feb 28 00:00:17 yami nextcloud.logrotate[384392]: Job for snap.nextcloud.php-fpm.service failed.
Feb 28 00:00:17 yami nextcloud.logrotate[384392]: See "systemctl status snap.nextcloud.php-fpm.service" and "journalctl -xe" for details.
Feb 28 00:00:17 yami nextcloud.logrotate[384392]: )
Feb 28 00:00:17 yami nextcloud.logrotate[384392]: - reload-or-restart of [nextcloud.php-fpm] (exit status 1)
Feb 28 00:00:17 yami nextcloud.logrotate[384222]: error: error running non-shared postrotate script for /var/snap/nextcloud/current/logs/php-fpm_errors.log of '/var/snap/nextcloud/current/logs/php_errors.log /var/snap/nextcloud/current/logs/php-fpm_errors.log /var/snap/nextcloud/current/logs/nextcloud.log '
```

As you can see the pid is not correctly set, this uses the same technique as earlier in the same file.

When calling a function, it is effectively an external program call
so needs to be wrapped in "$(..func...)"

Copy the same technique as in restart_php_if_running() and place the pid
into a variable and then send the USR1 signal.

This will mean reloading should now work properly.