### PR TITLE
nextcloud: update to 20.0.8

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,8 +188,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-20.0.7.tar.bz2
-    source-checksum: sha256/8ced82b772bf0af67d5be1323e40f977429bc0a2bcc864095efc78767500b72b
+    source: https://download.nextcloud.com/server/releases/nextcloud-20.0.8.tar.bz2
+    source-checksum: sha256/85746a4bda87bf754be5834cdb6489c365dc847653bab8ff3afccdaac3b356b5
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #1656 by updating Nextcloud to the latest v20 release.

