### PR TITLE
logrotate: rotate apache access log

### DIFF
--- a/src/logrotate/config/logrotate.conf
+++ b/src/logrotate/config/logrotate.conf
@@ -19,7 +19,7 @@ compress
 delaycompress
 
 # Apache logs
-$SNAP_DATA_CURRENT/logs/apache_errors.log {
+$SNAP_DATA_CURRENT/logs/apache_errors.log $SNAP_DATA_CURRENT/logs/apache_access.log {
 	postrotate
 		snapctl restart --reload $SNAP_INSTANCE_NAME.apache
 	endscript


### PR DESCRIPTION
This PR fixes #1668 by adding the Apache access log to the logrotate configuration file. 