### PR TITLE
Release 20.0.8snap1

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir -p /snap/snapcraft
 RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
 
 # Grab the go snap from the stable channel and unpack it in the proper place
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/go?channel=stable' | jq '.download_url' -r) --output go.snap
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/go?channel=1.15/stable' | jq '.download_url' -r) --output go.snap
 RUN mkdir -p /snap/go
 RUN unsquashfs -d /snap/go/current go.snap
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+v 20.0.8snap1
+  - logrotate: rotate apache access log
+  - redis: update to 5.0.12
+  - nextcloud: update to 20.0.8
+  - Correctly obtain the PHP-FPM pid before sending a signal
+  - php: update to 7.4.15
+
 v 20.0.7snap1
   - nextcloud: update to 20.0.7
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Nextcloud server packaged as a snap. It consists of:
 
-- Nextcloud 20.0.7
+- Nextcloud 20.0.8
 - Apache 2.4
 - PHP 7.3
 - MySQL 5.7

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -289,13 +289,13 @@ parts:
       sbin/php-fpm: bin/php-fpm
     extensions:
       # Build the redis PHP module
-      - source: https://github.com/phpredis/phpredis/archive/5.3.1.tar.gz
-        source-checksum: sha256/930dc88ef126509b8991c52757fdc68908c753b476ad6f25dae0ce6925870f14
+      - source: https://github.com/phpredis/phpredis/archive/5.3.3.tar.gz
+        source-checksum: sha256/7b0f487f8ad4b93ed0542a9bb650d4d47bea64abc54c9440280458f329bc34e7
 
   redis:
     plugin: redis
-    source: http://download.redis.io/releases/redis-5.0.8.tar.gz
-    source-checksum: sha256/f3c7eac42f433326a8d981b50dba0169fdfaf46abb23fcda2f933a7552ee4ed7
+    source: http://download.redis.io/releases/redis-5.0.12.tar.gz
+    source-checksum: sha256/7040eba5910f7c3d38f05ea5a1d88b480488215bdbd2e10ec70d18380108e31e
 
   redis-customizations:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -202,8 +202,8 @@ parts:
 
   php:
     plugin: php
-    source: https://php.net/get/php-7.4.14.tar.bz2/from/this/mirror
-    source-checksum: sha256/6889ca0605adee3aa7077508cd79fcef1dbd88461cdf25e7c1a86997b8d0a1f6
+    source: https://php.net/get/php-7.4.15.tar.bz2/from/this/mirror
+    source-checksum: sha256/1bd7be0293446c3d3cbe3c9fae6045119af0798fb0869db61932796dc23a7757
     source-type: tar
     install-via: prefix
     configflags:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,8 +188,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-20.0.7.tar.bz2
-    source-checksum: sha256/8ced82b772bf0af67d5be1323e40f977429bc0a2bcc864095efc78767500b72b
+    source: https://download.nextcloud.com/server/releases/nextcloud-20.0.8.tar.bz2
+    source-checksum: sha256/85746a4bda87bf754be5834cdb6489c365dc847653bab8ff3afccdaac3b356b5
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess

--- a/src/logrotate/config/logrotate.conf
+++ b/src/logrotate/config/logrotate.conf
@@ -19,7 +19,7 @@ compress
 delaycompress
 
 # Apache logs
-$SNAP_DATA_CURRENT/logs/apache_errors.log {
+$SNAP_DATA_CURRENT/logs/apache_errors.log $SNAP_DATA_CURRENT/logs/apache_access.log {
 	postrotate
 		snapctl restart --reload $SNAP_INSTANCE_NAME.apache
 	endscript

--- a/src/php/utilities/php-utilities
+++ b/src/php/utilities/php-utilities
@@ -54,7 +54,8 @@ php_pid()
 php_reload()
 {
 	if php_is_running; then
-		kill -USR1 php_pid > /dev/null
+		pid="$(php_pid)"
+		kill -USR1 "$pid" > /dev/null
 	fi
 }
 


### PR DESCRIPTION
- logrotate: rotate apache access log
- redis: update to 5.0.12
- nextcloud: update to 20.0.8
- Correctly obtain the PHP-FPM pid before sending a signal
- php: update to 7.4.15