### PR TITLE
Add permission-policy header, opt out of FloC

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v 20.0.9snap1
+  - mysql: update to 5.7.34
+  - nextcloud: update to 20.0.9
+
 v 20.0.8snap1
   - logrotate: rotate apache access log
   - redis: update to 5.0.12

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Nextcloud server packaged as a snap. It consists of:
 
-- Nextcloud 20.0.8
+- Nextcloud 20.0.9
 - Apache 2.4
 - PHP 7.3
 - MySQL 5.7

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -345,7 +345,7 @@ parts:
   mysql:
     plugin: cmake
     source: https://github.com/mysql/mysql-server.git
-    source-tag: mysql-5.7.33
+    source-tag: mysql-5.7.34
     source-depth: 1
     override-pull: |
       snapcraftctl pull

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,8 +188,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-20.0.8.tar.bz2
-    source-checksum: sha256/85746a4bda87bf754be5834cdb6489c365dc847653bab8ff3afccdaac3b356b5
+    source: https://download.nextcloud.com/server/releases/nextcloud-20.0.9.tar.bz2
+    source-checksum: sha256/c8fe4ae86bc51276be6d39cbaf3f45f3b29df901cd5a4163b8a6af0e09e9ff04
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess

--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -189,6 +189,11 @@ ServerSignature Off
     ServerSignature On
 </IfDefine>
 
+# Opt out of of FloC, see https://www.eff.org/deeplinks/2021/03/google-testing-its-controversial-new-ad-targeting-tech-millions-browsers-heres
+<IfModule mod_headers.c>
+  Header always set Permissions-Policy: interest-cohort=()
+</IfModule>
+
 # Only enable SSL if requested
 <IfDefine EnableHTTPS>
     Include ${SNAP}/conf/ssl.conf


### PR DESCRIPTION
Google is trying to enlarge it's monopoly with FloC. We should put all our efforts in blocking Google from doing so. 

Recently WordPress and Github decided to block FloC already, Nextcloud cannot be left behind, hence my proposal. Feel free to relocate this, if you believe this header should be placed elsewhere. 

More info on FloC:
https://www.eff.org/deeplinks/2021/03/google-testing-its-controversial-new-ad-targeting-tech-millions-browsers-heres