### PR TITLE
nextcloud: update to 21.0.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,8 +188,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-20.0.9.tar.bz2
-    source-checksum: sha256/c8fe4ae86bc51276be6d39cbaf3f45f3b29df901cd5a4163b8a6af0e09e9ff04
+    source: https://download.nextcloud.com/server/releases/nextcloud-21.0.1.tar.bz2
+    source-checksum: sha256/dd7c8ccc01547914a75b44bbf86028289c8919dc39f4e2e720147b6bd596aebe
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
This PR resolves #1727 by upgrading Nextcloud to the latest v21 release.