### PR TITLE
myqsl: expire binlog after 7 days

### DIFF
--- a/src/mysql/my.cnf
+++ b/src/mysql/my.cnf
@@ -3,5 +3,6 @@ user=root
 max_allowed_packet=100M
 secure-file-priv=NULL
 skip-networking
+binlog_expire_logs_seconds=604800
 transaction_isolation=READ-COMMITTED
 log_error=../logs/mysql_errors.log


### PR DESCRIPTION
The default expiration is 30 days, which is just too long for some instances and takes up too much space. This PR resolves #1742 by setting it to 7 instead.