### PR TITLE
mysql: disable binary logging

### DIFF
--- a/src/mysql/my.cnf
+++ b/src/mysql/my.cnf
@@ -3,5 +3,6 @@ user=root
 max_allowed_packet=100M
 secure-file-priv=NULL
 skip-networking
+skip-log-bin
 transaction_isolation=READ-COMMITTED
 log_error=../logs/mysql_errors.log


### PR DESCRIPTION
This was disabled in v5.7, and is supposed to be disabled in v8 when initialized with the method we're using. See [the docs](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html), particularly this quote:

> In earlier MySQL versions, binary logging was disabled by default, and was enabled if you specified the --log-bin option. From MySQL 8.0, binary logging is enabled by default, whether or not you specify the --log-bin option. The exception is if you use mysqld to initialize the data directory manually by invoking it with the --initialize or --initialize-insecure option, when binary logging is disabled by default.

We [do indeed initialize mysql that way](https://github.com/nextcloud/nextcloud-snap/blob/master/src/mysql/bin/start_mysql#L17), but the binlog is still enabled, so I suspect that's a bug. This PR resolves #1742 by disabling the binlog to keep the same behavior as before the upgrade to v8. We're not replicating, anyway-- this should be unnecessary.