### PR TITLE
apache: log X-Forwarded-For

### DIFF
--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -163,7 +163,7 @@ ProxyFCGIBackendType GENERIC
 </Proxy>
 
 # The "combined" format is taken from the Ubuntu Apache config
-LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%h %{X-Forwarded-For}i %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
 
 #
 # Default log location. If you define an error logfile for a <VirtualHost>


### PR DESCRIPTION
If the snap is behind a reverse-proxy, the only host IP address it'll see is that of the proxy. Most proxies send the actual host IP along in the X-Forwarded-For header, though. This PR resolves #1610 by logging that as well.