### PR TITLE
mysql: enable mysql_native_password

### DIFF
--- a/src/mysql/my.cnf
+++ b/src/mysql/my.cnf
@@ -7,3 +7,4 @@ skip-log-bin
 transaction_isolation=READ-COMMITTED
 log_error=../logs/mysql_errors.log
 performance_schema=OFF
+mysql_native_password=ON


### PR DESCRIPTION
This will be deprecated in MySQL 9.0, but it's still available in version 8.4.
We should do [the proper migration though](https://php.watch/articles/fix-php-mysql-84-mysql_native_password-not-loaded).