### PR TITLE
mysql: migrate users to caching_sha2_password plugin

### DIFF
--- a/src/mysql/my.cnf
+++ b/src/mysql/my.cnf
@@ -7,3 +7,4 @@ skip-log-bin
 transaction_isolation=READ-COMMITTED
 log_error=../logs/mysql_errors.log
 performance_schema=OFF
+mysql_native_password=ON

--- a/src/nextcloud/fixes/existing-install/maintenance/3_mysql-use-caching_sha2_password.sh
+++ b/src/nextcloud/fixes/existing-install/maintenance/3_mysql-use-caching_sha2_password.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# Version 32.0.8snap3 introduced MySQL v8.4, which disables `mysql_native_password`
+# by default. Let's make sure that our users are migrated to use
+# `caching_sha2_password`.
+set -e
+
+# shellcheck source=src/mysql/utilities/mysql-utilities
+. "$SNAP/utilities/mysql-utilities"
+
+root_password="$(sed -rn 's/password=(.*)/\1/p' "$MYSQL_ROOT_OPTION_FILE")"
+nextcloud_password="$(mysql_get_nextcloud_password)"
+
+"$SNAP"/bin/run-mysql <<SQL
+ALTER USER 'root'@'localhost' IDENTIFIED WITH caching_sha2_password BY '$root_password';
+ALTER USER 'nextcloud'@'localhost' IDENTIFIED WITH caching_sha2_password BY '$nextcloud_password';
+SQL


### PR DESCRIPTION
The `mysql_native_password` plugin has been deprecated for a while, but was finally disabled by default in MySQL v8.4, which made it catch our attention. Some long-running installations will still be using `mysql_native_password`; migrate those installations to `caching_sha2_password`.

`mysql_native_password=ON` needs to be in the config in order to actually complete this migration. We can remove it in a future update.