### PR TITLE
Migrate legacy webroot plugin

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -179,11 +179,18 @@ parts:
       '.htaccess': htdocs/.htaccess
       '.user.ini': htdocs/.user.ini
       '.reuse': htdocs/.reuse
+    
 
     # This snap automatically updates. No need to include the updater to nag
     # users. This does not result in an integrity check failure.
     prime:
       - -htdocs/apps/updatenotification
+
+  nextcloud-fixer:
+    plugin: nil
+    stage-packages:
+      - mawk
+      - sed
 
   php:
     plugin: autotools

--- a/src/https/bin/enable-https
+++ b/src/https/bin/enable-https
@@ -111,14 +111,8 @@ handle_lets_encrypt()
 	# Building CLI commands, so we don't WANT to quote some of these (they need
 	# to be separated by whitespace): disable the check
 	# shellcheck disable=SC2086
-	if ! output="$(run_certbot certonly $extra_params \
-	             --authenticator webroot \
-	             --webroot-path "$CERTBOT_DIRECTORY" \
-	             --rsa-key-size 4096 \
+	if ! output="$(run_certbot_certonly $extra_params \
 	             --email "$email" \
-	             --non-interactive \
-	             --agree-tos \
-	             --force-renewal \
 	             $domains 2>&1)"; then
 		printf "error running certbot:\n\n" >&2
 		echo "$output" >&2

--- a/src/https/utilities/https-utilities
+++ b/src/https/utilities/https-utilities
@@ -106,12 +106,17 @@ deactivate_certificates()
 	rm -rf "$LIVE_CERTS_DIRECTORY"
 }
 
+get_most_recent_certificate_directory()
+{
+	find "$CERTBOT_LIVE_DIRECTORY" -maxdepth 1 -mindepth 1 -not -iname readme -printf "%T@ %P\n" | sort -rn | cut -d " " -f2 | head -1
+}
+
 activate_certbot_certificate()
 {
 	# Multiple domains can accumulate if the user runs the command multiple
 	# times. So we find and use the folder that was most recently modified,
 	# which will contain the most recent certs. Ignore any READMEs.
-	certdir="$(find "$CERTBOT_LIVE_DIRECTORY" -maxdepth 1 -mindepth 1 -not -iname readme -printf "%T@ %P\n" | sort -rn | cut -d " " -f2 | head -1)"
+	certdir="$(get_most_recent_certificate_directory)"
 
 	deactivate_certificates
 	ln -s "$CERTBOT_LIVE_DIRECTORY/$certdir" "$LIVE_CERTS_DIRECTORY"
@@ -140,4 +145,16 @@ run_certbot()
 	certbot --text --config-dir "$CERTBOT_DIRECTORY/config" \
 	               --work-dir "$CERTBOT_DIRECTORY/work" \
 	               --logs-dir "$CERTBOT_DIRECTORY/logs" "$@"
+}
+
+run_certbot_certonly()
+{
+	run_certbot certonly \
+		--authenticator webroot \
+		--webroot-path "$CERTBOT_DIRECTORY" \
+		--rsa-key-size 4096 \
+		--non-interactive \
+		--agree-tos \
+		--force-renewal \
+		"$@"
 }

--- a/src/nextcloud/fixes/existing-install/maintenance/04_migrate-webroot-plugin.sh
+++ b/src/nextcloud/fixes/existing-install/maintenance/04_migrate-webroot-plugin.sh
@@ -1,0 +1,142 @@
+#!/bin/sh
+# 
+# The custom nextcloud plugin for certbot was replaced by the official 
+# webroot plugin in Version 15.0.8snap2. This script should migrate
+# existing installations to use the webroot plugin.
+
+set -e
+
+# shellcheck source=src/https/utilities/https-utilities
+. "$SNAP/utilities/https-utilities"
+
+printf "Checking if the certbot plugin needs to be migrated... "
+
+if ! certificates_are_active; then
+    echo "no (no HTTPS certificates are active)"
+    exit
+fi
+
+if self_signed_certificates_are_active || custom_certificates_are_active; then
+    echo "Not using certbot certificates, so no migration is needed."
+    exit
+fi
+
+certdir="$(get_most_recent_certificate_directory)"
+RENEWAL_CONFIG_FILE="$SNAP_CURRENT/certs/certbot/config/renewal/$certdir.conf"
+
+if [ ! -f "$RENEWAL_CONFIG_FILE" ]; then
+    echo "no (renewal config file not found)"
+    exit 1
+fi
+
+if grep -q "authenticator = nextcloud:webroot" "$RENEWAL_CONFIG_FILE"; then
+    echo "yes"
+else
+    echo "no"
+    exit 0
+fi
+
+# Extract the domains from the certificate
+AWK_CMD="/^[[:space:]]*X509v3 Subject Alternative Name:/ {
+    capture=1
+    next
+}
+
+/^[[:space:]]*X509v3/ {
+    if (capture) exit
+}
+
+capture {
+    print
+}"
+
+domains=$(openssl x509 -noout -text -in "$CERTBOT_LIVE_DIRECTORY/$certdir/cert.pem" | mawk "$AWK_CMD" | sed -e 's/^[[:space:]]*//g' | tr -d "," | sed -e 's/DNS://g')
+echo "Found domains to be migrated: $domains"
+
+# Collect all parameters to be used with certbot.
+extra_params=""
+
+# Check the current ACME server
+acme_server=$(grep -E "^server\s*=\s*" "$RENEWAL_CONFIG_FILE" | sed -e 's/^[[:space:]]*server\s*=\s*//g')
+if [ "$acme_server" = "https://acme-v02.api.letsencrypt.org/directory" ]; then
+    # Default (productive) ACME server, so nothing is needed
+    :
+elif [ "$acme_server" = "https://acme-staging-v02.api.letsencrypt.org/directory" ]; then
+    # Staging ACME server, so we need to add the --staging flag to the certbot command
+    extra_params="--staging"
+else
+    echo "error: unrecognized ACME server: $acme_server" >&2
+    exit 1
+fi
+
+for domain in $domains; do
+    extra_params="$extra_params -d $domain"
+done
+
+printf "Testing if certificates can be obtained with the webroot plugin... "
+
+# Building CLI commands, so we don't WANT to quote some of these (they need
+# to be separated by whitespace): disable the check
+# shellcheck disable=SC2086
+if output="$(run_certbot_certonly $extra_params --staging --dry-run 2>&1)"; then
+    echo "success"
+else
+    echo "failed!"
+    echo "error running certbot:" >&2
+    echo "" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+# Copy the legacy plugin to a temporary location.
+cp -R --preserve=timestamps,mode "$SNAP_CURRENT/certs/certbot" "$SNAP_CURRENT/certs/certbot.legacy"
+
+printf "Migrating certbot configuration to use the webroot plugin... "
+
+trap_for_error() {
+    retVal=$?
+
+    # No issue found. We are safe. Exit with success.
+    if [ "$retVal" -eq 0 ]; then
+        exit 0
+    fi
+
+    echo ""
+    echo "An error occurred during the migration process. Restoring legacy certbot configuration."
+
+    rm -rf "$SNAP_CURRENT/certs/certbot"
+    mv "$SNAP_CURRENT/certs/certbot.legacy" "$SNAP_CURRENT/certs/certbot"
+
+    exit "$retVal"
+}
+# Install a trap in case something goes wrong during the migration process, so we can restore the
+# legacy configuration and avoid leaving the user with a broken certbot configuration.
+trap trap_for_error EXIT INT TERM HUP
+
+# Drop old configuration files of the active certificate
+rm -rf \
+    "$SNAP_CURRENT/certs/certbot/config/archive/$certdir" \
+    "$SNAP_CURRENT/certs/certbot/config/live/$certdir" \
+    "$SNAP_CURRENT/certs/certbot/config/renewal/$certdir.conf"
+
+# Building CLI commands, so we don't WANT to quote some of these (they need
+# to be separated by whitespace): disable the check
+# shellcheck disable=SC2086
+if output="$(run_certbot_certonly $extra_params 2>&1)"; then
+    echo "success"
+
+    # Disable the trap to avoid restoring the legacy configuration after a successful migration
+    trap - EXIT INT TERM HUP
+else
+    echo "failed!"
+    echo "error running certbot:" >&2
+    echo "" >&2
+    echo "$output" >&2
+
+    exit 1
+fi
+
+echo "Removing legacy certbot configuration."
+rm -rf "$SNAP_CURRENT/certs/certbot.legacy"
+
+activate_certbot_certificate

--- a/src/nextcloud/fixes/existing-install/maintenance/4_migrate-webroot-plugin.sh
+++ b/src/nextcloud/fixes/existing-install/maintenance/4_migrate-webroot-plugin.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# 
+# The custom nextcloud plugin for certbot was replaced by the official 
+# webroot plugin in Version 15.0.8snap2. This script should migrate
+# existing installations to use the webroot plugin.
+
+set -e
+
+# shellcheck source=src/https/utilities/https-utilities
+. "$SNAP/utilities/https-utilities"
+
+echo -n "Checking if the certbot plugin needs to be migrated... "
+
+if ! certificates_are_active; then
+    echo "no (no HTTPS certificates are active)"
+    exit
+fi
+
+certdir="$(get_most_recent_certificate_directory)"
+RENEWAL_CONFIG_FILE="$SNAP_CURRENT/certs/certbot/renewal/$certdir.conf"
+
+if [ ! -f "$RENEWAL_CONFIG_FILE" ]; then
+    echo "no (renewal config file not found)"
+    exit 1
+fi
+
+if grep -q "authenticator = nextcloud:webroot" "$RENEWAL_CONFIG_FILE"; then
+    echo "yes"
+else
+    echo "no"
+    exit 0
+fi
+
+# Extract the domains from the certificate
+AWK_CMD="/^[[:space:]]*X509v3 Subject Alternative Name:/ {
+    capture=1
+    next
+}
+
+/^[[:space:]]*X509v3/ {
+    if (capture) exit
+}
+
+capture {
+    print
+}"
+
+domains=$(openssl x509 -noout -text -in "$CERTBOT_LIVE_DIRECTORY/cert.pem" | mawk "$AWK_CMD" | sed -e 's/^[[:space:]]*//g' | tr -d "," | sed -e 's/DNS://g')
+echo "Found domains to be migrated: $domains"
+
+# Collect all parameters to be used with certbot.
+extra_params=""
+dry_run=n
+
+# Check the current ACME server
+acme_server=$(grep -E "^server\s*=\s*" "$RENEWAL_CONFIG_FILE" | sed -e 's/^[[:space:]]*server\s*=\s*//g')
+if [ "$acme_server" = "https://acme-v02.api.letsencrypt.org/directory" ]; then
+    # Default (productive) ACME server, so nothing is needed
+    :
+elif [ "$acme_server" = "https://acme-staging-v02.api.letsencrypt.org/directory" ]; then
+    # Staging ACME server, so we need to add the --staging flag to the certbot command
+    extra_params="--staging"
+    dry_run=y
+else
+    echo "error: unrecognized ACME server: $acme_server" >&2
+    exit 1
+fi
+
+for domain in $domains; do
+    extra_params="$extra_params -d $domain"
+done
+
+echo -n "Testing if certificates can be obtained with the webroot plugin... "
+
+if output="$(run_certbot_certonly $extra_params --staging --dry-run" 2>&1)"; then
+    echo "success"
+else
+    echo "failed!"
+    echo "error running certbot:\n\n" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+# Moving the legacy plugin to a temporary location.
+mv "$SNAP_CURRENT/certs/certbot" "$SNAP_CURRENT/certs/certbot.legacy"
+
+echo "Migrating certbot configuration to use the webroot plugin... "
+
+if output="$(run_certbot_certonly $extra_params 2>&1)"; then
+    echo "success"
+else
+    echo "failed!"
+    echo "error running certbot:\n\n" >&2
+    echo "$output" >&2
+
+    echo "Restoring legacy certbot configuration."
+    rm -rf "$SNAP_CURRENT/certs/certbot"
+    mv "$SNAP_CURRENT/certs/certbot.legacy" "$SNAP_CURRENT/certs/certbot"
+
+    exit 1
+fi
+
+echo "Removing legacy certbot configuration."
+rm -rf "$SNAP_CURRENT/certs/certbot.legacy"

--- a/src/nextcloud/fixes/existing-install/maintenance/4_migrate-webroot-plugin.sh
+++ b/src/nextcloud/fixes/existing-install/maintenance/4_migrate-webroot-plugin.sh
@@ -9,10 +9,15 @@ set -e
 # shellcheck source=src/https/utilities/https-utilities
 . "$SNAP/utilities/https-utilities"
 
-echo -n "Checking if the certbot plugin needs to be migrated... "
+printf "Checking if the certbot plugin needs to be migrated... "
 
 if ! certificates_are_active; then
     echo "no (no HTTPS certificates are active)"
+    exit
+fi
+
+if self_signed_certificates_are_active || custom_certificates_are_active; then
+    echo "Not using certbot certificates, so no migration is needed."
     exit
 fi
 
@@ -70,27 +75,39 @@ for domain in $domains; do
     extra_params="$extra_params -d $domain"
 done
 
-echo -n "Testing if certificates can be obtained with the webroot plugin... "
+printf "Testing if certificates can be obtained with the webroot plugin... "
 
-if output="$(run_certbot_certonly $extra_params --staging --dry-run" 2>&1)"; then
+# Building CLI commands, so we don't WANT to quote some of these (they need
+# to be separated by whitespace): disable the check
+# shellcheck disable=SC2086
+if output="$(run_certbot_certonly $extra_params --staging --dry-run 2>&1)"; then
     echo "success"
 else
     echo "failed!"
-    echo "error running certbot:\n\n" >&2
+    echo "error running certbot:" >&2
+    echo "" >&2
     echo "$output" >&2
     exit 1
+fi
+
+if [ "$dry_run" = "y" ]; then
+    extra_params="$extra_params --staging"
 fi
 
 # Moving the legacy plugin to a temporary location.
 mv "$SNAP_CURRENT/certs/certbot" "$SNAP_CURRENT/certs/certbot.legacy"
 
-echo "Migrating certbot configuration to use the webroot plugin... "
+printf "Migrating certbot configuration to use the webroot plugin... "
 
+# Building CLI commands, so we don't WANT to quote some of these (they need
+# to be separated by whitespace): disable the check
+# shellcheck disable=SC2086
 if output="$(run_certbot_certonly $extra_params 2>&1)"; then
     echo "success"
 else
     echo "failed!"
-    echo "error running certbot:\n\n" >&2
+    echo "error running certbot:" >&2
+    echo "" >&2
     echo "$output" >&2
 
     echo "Restoring legacy certbot configuration."
@@ -102,3 +119,5 @@ fi
 
 echo "Removing legacy certbot configuration."
 rm -rf "$SNAP_CURRENT/certs/certbot.legacy"
+
+activate_certbot_certificate


### PR DESCRIPTION
This is a fixer script to help get rid of the manually managed Nextcloud plugin for Certbot. 

This one needs thorough testing on an instance migrated from the ancient times to check the migration script actually works as expected.

This is a prestep for #1902 
Prepares #3419

---

- [x] Use current webroot plugin to obtain a valid certificate. The fixer should not try to create new certs.
- [x] Use of current webroot cert from staging should not trigger a new certificate.
- [x] Usage of self-signed certs should not trigger a new certificate
- [x] Usage of custom certs should not trigger a new certificate
- [x] Usage of a legacy staging certificate should migrate to a webroot staging certificate (using 1 domain)
- [x] Usage of a legacy staging certificate should migrate to a webroot staging certificate (using multiple domains)
- [x] Usage of a legacy production certificate should migrate to a webroot production certificate
