### PR TITLE
certbot: add workaround for zope* dependencies on arm64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -432,6 +432,22 @@ parts:
       snapcraftctl build
       patch -p1 -d $SNAPCRAFT_PART_INSTALL/lib/python3*/site-packages/certbot < $SNAPCRAFT_STAGE/certbot-remove-default-config-files.patch
       patch -p1 -d $SNAPCRAFT_PART_INSTALL/lib/python3*/site-packages/certbot < $SNAPCRAFT_STAGE/certbot-remove-storage-chown.patch
+    override-prime: |
+      snapcraftctl prime
+      cd "$SNAPCRAFT_PRIME/lib/python3.8/site-packages/"
+      
+      # If we have the dir with the underscore, make a link with the dot.
+      # This is needed to solve a issue affecting arm64. See #3461
+      for pkg in zope_interface zope_hookable zope_proxy
+      do
+        for filename in ./$pkg-*.dist-info
+        do
+          if [ -d "$filename" ]; then
+            # Replace underscores in pkg name, then strip the ./pkg prefix from filename
+            ln -sf "$filename" "${pkg//_/.}${filename#./$pkg}"
+          fi
+        done
+      done
 
   setup-https:
     plugin: dump


### PR DESCRIPTION
It looks like we are currently in a "messy middle" phase regarding Python metadata.

According to Gemini, on amd64 the building is likely pulling pre-compiled Wheels from PyPI. Those Wheels were built with an older naming convention, so they keep the dot: zope.*
On arm64, there likely isn't a pre-compiled Wheel for zope.* dependencies, it needs to be built from the Source Distribution (sdist). Because the build is happening on a newer core20 system, the modern build tools normalize the names to zope_*

Instead of fighting the naming convention, we simply "alias" the directories so that pkg_resources finds them on arm64.

I've built this on an arm64 VM and I've done this after installing it:
```
$ snap run --shell nextcloud.occ
To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

ubuntu@gleaming-cuckoo:/home/ubuntu$ certbot --version
certbot 0.39.0
```

So it seems to do the trick.

This should fix https://github.com/nextcloud-snap/nextcloud-snap/issues/3461