### PR TITLE
Release 32.0.8snap5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v 32.0.8snap5
+  - php: update to 8.3.31
+
 v 32.0.8snap4
   - mysql: update to 8.4.9
   - redis: update to 8.2.6

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -187,8 +187,8 @@ parts:
 
   php:
     plugin: autotools
-    source: https://php.net/get/php-8.3.29.tar.bz2/from/this/mirror
-    source-checksum: sha256/c7337212e655325d499ea8108fa76f69ddde2fff7cb0fad36aa63eed540cb8a5
+    source: https://php.net/get/php-8.3.31.tar.bz2/from/this/mirror
+    source-checksum: sha256/e6986b1fd37eb25402127fe4a7278a3e03b7f9025bb7a4bd292a271bdf930fb9
     source-type: tar
     autotools-configure-parameters:
       - --prefix=$SNAPCRAFT_PART_INSTALL


### PR DESCRIPTION
I don't think we can wait 19 days, when the next nextcloud version is scheduled, to release a snap with the [recent PHP security update](https://www.php.net/ChangeLog-8.php#8.2.31).
@nextcloud-snap/developers WDYT?