### PR TITLE
Release 32.0.9snap1

### DIFF
--- a/.github/workflows/test-daily.yml
+++ b/.github/workflows/test-daily.yml
@@ -15,7 +15,7 @@ jobs:
         run: sudo snap install --edge nextcloud
 
       - name: Setup ruby
-        uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1.301.0
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           working-directory: tests
           bundler-cache: true
@@ -34,7 +34,7 @@ jobs:
         run: sudo snap install nextcloud --channel=32/edge
 
       - name: Setup ruby
-        uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1.301.0
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           working-directory: tests
           bundler-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
         run: sudo snap install *.snap --dangerous
 
       - name: Setup ruby
-        uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1.301.0
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           working-directory: tests
           bundler-cache: true

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v 32.0.9snap1
+  - nextcloud: update to 32.0.9
+
 v 32.0.8snap5
   - php: update to 8.3.31
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -172,8 +172,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-32.0.8.tar.bz2
-    source-checksum: sha256/58ad8ddf860d75a294b97a8e3e39562dec87ff650cb91c114589b3744ab1de0d
+    source: https://download.nextcloud.com/server/releases/nextcloud-32.0.9.tar.bz2
+    source-checksum: sha256/fd6d591975efde1caf0e8427a82baa55a4a8b7ae643da29ed83e299c208c1eee
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
As discussed in https://github.com/nextcloud-snap/nextcloud-snap/pull/3469, I think it makes sense to release this.